### PR TITLE
[ci] fix map command

### DIFF
--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -169,6 +169,8 @@ def map_commands(
 ):
     steps = steps.copy()
     for step in steps:
+        if key not in step:
+            continue
         new_vals = []
         for val in step[key]:
             new_vals += map_fn(val)


### PR DESCRIPTION
The current map command function assumes that a step always has some "command" as a key. This is not entire true, in particular for trigger step like in https://github.com/ray-project/ray/pull/36972/files.

Do not update the step if a key is not part of the step.


Check error in https://buildkite.com/ray-project/oss-ci-build-pr/builds/27258#01890995-47ad-4632-9ca1-508796477dba

```
Traceback (most recent call last):
--
  | File "/tmp/tmp.FL5QpzPzXg/ray_ci/pipeline_ci.py", line 317, in <module>
  | main()
  | File "/var/lib/buildkite-agent/.local/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
  | return self.main(*args, **kwargs)
  | File "/var/lib/buildkite-agent/.local/lib/python3.7/site-packages/click/core.py", line 1055, in main
  | rv = self.invoke(ctx)
  | File "/var/lib/buildkite-agent/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
  | return ctx.invoke(self.callback, **ctx.params)
  | File "/var/lib/buildkite-agent/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
  | return __callback(*args, **kwargs)
  | File "/tmp/tmp.FL5QpzPzXg/ray_ci/pipeline_ci.py", line 294, in main
  | pipeline_steps = map_commands(pipeline_steps, map_fn=_print_command)
  | File "/tmp/tmp.FL5QpzPzXg/ray_ci/pipeline_ci.py", line 173, in map_commands
  | for val in step[key]:
  | KeyError: 'commands'


```