### PR TITLE
[ci] Support triggering of non-command steps

### DIFF
--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -71,7 +71,10 @@ def read_pipeline(pipeline_path: Path):
     if isinstance(steps, dict) and "steps" in steps:
         steps = steps["steps"]
 
-    return steps, group_name
+    command_steps = [step for step in steps if "commands" in step]
+    non_command_steps = [step for step in steps if "commands" not in step]
+
+    return command_steps, non_command_steps, group_name
 
 
 def filter_pipeline_conditions(
@@ -247,7 +250,7 @@ def main(
     assert queue
     assert not (early_only and not_early_only)
 
-    pipeline_steps, group_name = read_pipeline(pipeline_path)
+    pipeline_steps, other_pipeline_steps, group_name = read_pipeline(pipeline_path)
 
     # Filter early kick-off
     if early_only:
@@ -307,7 +310,7 @@ def main(
     if group_name and len(pipeline_steps) > 0:
         pipeline_steps = [{
             "group": group_name,
-            "steps": pipeline_steps,
+            "steps": pipeline_steps + other_pipeline_steps,
         }]
 
     # Print to stdout


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/36972 adds triggering steps as part of pipeline.yaml file. The current pipeline_ci.py assumes that all steps are command steps though.

Separate command steps and non-command steps, and just leave the format of non-command steps as they are.