### PR TITLE
add ray_ci python test

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,7 @@
 steps:
   - label: "ray_ci test"
     commands:
+      - yum install -y pip
       - pip install pytest click pyyaml
       - (cd ray_ci; pytest -v .)
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ steps:
     commands:
       - yum install -y pip
       - pip install pytest click pyyaml
-      - (cd ray_ci; pytest -v .)
+      - (cd ray_ci; python3 -m pytest -v .)
     plugins:
       - docker#v5.7.0:
           image: amazonlinux:2

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,8 +1,8 @@
 steps:
   - label: "ray_ci test"
     commands:
-      - yum install -y pip
-      - pip install pytest click pyyaml
+      - yum install -y python3
+      - pip3 install pytest click pyyaml
       - (cd ray_ci; python3 -m pytest -v .)
     plugins:
       - docker#v5.7.0:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@ steps:
       - (cd ray_ci; pytest -v .)
     plugins:
       - docker#v5.7.0:
-          image: amazonlinux:2023
+          image: amazonlinux:2
           shell: ["/bin/bash", "-elic"]
     agents:
       queue: "runner_queue_branch"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,5 +1,11 @@
 steps:
-  - label: "hello"
-    commands: 'echo hello'
+  - label: "ray_ci test"
+    commands:
+      - pip install pytest click pyyaml
+      - (cd ray_ci; pytest -v .)
+    plugins:
+      - docker#v5.7.0
+          image: amazonlinux:2023
+          shell: ["/bin/bash", "-elic"]
     agents:
       queue: "runner_queue_branch"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,7 +4,7 @@ steps:
       - pip install pytest click pyyaml
       - (cd ray_ci; pytest -v .)
     plugins:
-      - docker#v5.7.0
+      - docker#v5.7.0:
           image: amazonlinux:2023
           shell: ["/bin/bash", "-elic"]
     agents:


### PR DESCRIPTION
to prevent regression on python scripts.

runs in amazonlinux:2 because that is what is used in buildkite ami.