### PR TITLE
add forge building

### DIFF
--- a/raycicmd/forge.go
+++ b/raycicmd/forge.go
@@ -1,6 +1,10 @@
 package raycicmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -15,4 +19,85 @@ func forgeNameFromDockerfile(name string) (string, bool) {
 		return "", false
 	}
 	return name, true
+}
+
+// builtin builder command to build a forge container image.
+const forgeBuilderCommand = `/bin/bash -euo pipefail -c ` +
+	`'export DOCKER_BUILDKIT=1 ; ` +
+	`DEST_IMG="$${RAYCI_TMP_REPO}:$${RAYCI_BUILD_ID}-$${RAYCI_FORGE_NAME}" ; ` +
+	`tar --mtime="UTC 2020-01-01" -c -f - "$${RAYCI_FORGE_DOCKERFILE}" |` +
+	` docker build --progress=plain -t "$${DEST_IMG}" ` +
+	` -f "$${RAYCI_FORGE_DOCKERFILE}" - ; ` +
+	`docker push "$${DEST_IMG}" '`
+
+func makeForgeStep(buildID, name, file string, config *config) map[string]any {
+	agent := ""
+	if config.BuilderQueues != nil {
+		if q, ok := config.BuilderQueues["builder"]; ok {
+			agent = q
+		}
+	}
+
+	bkStep := map[string]any{
+		"label":    name,
+		"key":      name,
+		"commands": []string{forgeBuilderCommand},
+		"env": map[string]string{
+			"RAYCI_BUILD_ID":         buildID,
+			"RAYCI_TMP_REPO":         config.CITempRepo,
+			"RAYCI_FORGE_DOCKERFILE": file,
+			"RAYCI_FORGE_NAME":       name,
+		},
+	}
+	if agent != "" {
+		bkStep["agents"] = newBkAgents(agent)
+	}
+
+	return bkStep
+}
+
+func makeForgeGroup(repoDir, buildID string, config *config) (
+	*bkPipelineGroup, error,
+) {
+	g := &bkPipelineGroup{
+		Group: "forge",
+		Key:   "all-forges",
+	}
+
+	// add forge container building steps
+	for _, dir := range config.ForgeDirs {
+		entries, err := os.ReadDir(filepath.Join(repoDir, dir))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read forge dir %s: %w", dir, err)
+		}
+
+		var names []string
+		forgeNames := make(map[string]string)
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			forgeName, ok := forgeNameFromDockerfile(name)
+			if !ok {
+				continue
+			}
+			names = append(names, name)
+			forgeNames[name] = forgeName
+		}
+
+		sort.Strings(names)
+		for _, name := range names {
+			forgeName := forgeNames[name]
+			filePath := filepath.Join(dir, name)
+			step := makeForgeStep(buildID, forgeName, filePath, config)
+			g.Steps = append(g.Steps, step)
+		}
+	}
+
+	return g, nil
 }

--- a/raycicmd/forge_test.go
+++ b/raycicmd/forge_test.go
@@ -2,6 +2,11 @@ package raycicmd
 
 import (
 	"testing"
+
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 )
 
 func TestForgeName(t *testing.T) {
@@ -36,4 +41,208 @@ func TestForgeName(t *testing.T) {
 			t.Errorf("forgeNameFromDockerfile(%q): got ok, want !ok", file)
 		}
 	}
+}
+
+func jsonString(v interface{}) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestMakeForgeGroup(t *testing.T) {
+	config := &config{
+		name: "test",
+
+		ArtifactsBucket: "rayci-artifacts",
+
+		CITemp:     "s3://ci-temp",
+		CITempRepo: rayCIECR + "/rayci_test",
+
+		BuilderQueues: map[string]string{
+			"builder": "builder_queue",
+		},
+
+		ForgeDirs: []string{
+			"ci/forge",
+			"civ2/forge",
+		},
+	}
+
+	buildID := "fakebuild"
+
+	t.Run("no forge", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "ci/forge"), 0700); err != nil {
+			t.Fatalf("make forge dir: %v", err)
+		}
+		g, err := makeForgeGroup(root, buildID, config)
+		if err != nil {
+			t.Fatalf("make forge group: %v", err)
+		}
+
+		if len(g.Steps) != 0 {
+			t.Errorf("makeForgeGroup(): got %d steps, want 0", len(g.Steps))
+		}
+	})
+
+	t.Run("one forge dir ", func(t *testing.T) {
+		root := t.TempDir()
+
+		if err := os.MkdirAll(filepath.Join(root, "ci/forge"), 0700); err != nil {
+			t.Fatalf("make forge dir: %v", err)
+		}
+
+		p := filepath.Join(root, "ci/forge/Dockerfile.forge")
+		content := []byte(`FROM ubuntu:latest`)
+		if err := os.WriteFile(p, content, 0600); err != nil {
+			t.Fatalf("write forge file: %v", err)
+		}
+
+		p = filepath.Join(root, "ci/forge/Dockerfile.wheel-forge")
+		content = []byte(`FROM manylinux2014`)
+		if err := os.WriteFile(p, content, 0600); err != nil {
+			t.Fatalf("write wheel-forge file: %v", err)
+		}
+
+		g, err := makeForgeGroup(root, buildID, config)
+		if err != nil {
+			t.Fatalf("make forge group: %v", err)
+		}
+
+		if g.Group != "forge" {
+			t.Errorf("got group %q, want %q", g.Group, "forge")
+		}
+		if g.Key != "all-forges" {
+			t.Errorf("got key %q, want %q", g.Key, "all-forges")
+		}
+		if len(g.Steps) != 2 {
+			t.Fatalf("got %d steps, want 1", len(g.Steps))
+		}
+
+		step := g.Steps[0].(map[string]any)
+		want := map[string]any{
+			"label":    "forge",
+			"key":      "forge",
+			"commands": []string{forgeBuilderCommand},
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":         buildID,
+				"RAYCI_TMP_REPO":         config.CITempRepo,
+				"RAYCI_FORGE_DOCKERFILE": "ci/forge/Dockerfile.forge",
+				"RAYCI_FORGE_NAME":       "forge",
+			},
+			"agents": map[string]any{"queue": "builder_queue"},
+		}
+		if !reflect.DeepEqual(step, want) {
+			t.Errorf(
+				"got step 1 %s\n, want %s",
+				jsonString(step),
+				jsonString(want),
+			)
+		}
+
+		step = g.Steps[1].(map[string]any)
+		want = map[string]any{
+			"label":    "wheel-forge",
+			"key":      "wheel-forge",
+			"commands": []string{forgeBuilderCommand},
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":         buildID,
+				"RAYCI_TMP_REPO":         config.CITempRepo,
+				"RAYCI_FORGE_DOCKERFILE": "ci/forge/Dockerfile.wheel-forge",
+				"RAYCI_FORGE_NAME":       "wheel-forge",
+			},
+			"agents": map[string]any{"queue": "builder_queue"},
+		}
+		if !reflect.DeepEqual(step, want) {
+			t.Errorf(
+				"got step 2 %s\n, want %s",
+				jsonString(step),
+				jsonString(want),
+			)
+		}
+
+	})
+
+	// For having forges from two different directories.
+	t.Run("two forge dirs", func(t *testing.T) {
+		root := t.TempDir()
+
+		if err := os.MkdirAll(filepath.Join(root, "ci/forge"), 0700); err != nil {
+			t.Fatalf("make forge dir: %v", err)
+		}
+
+		p := filepath.Join(root, "ci/forge/Dockerfile.forge")
+		content := []byte(`FROM ubuntu:latest`)
+		if err := os.WriteFile(p, content, 0600); err != nil {
+			t.Fatalf("write forge file: %v", err)
+		}
+
+		if err := os.MkdirAll(filepath.Join(root, "civ2/forge"), 0700); err != nil {
+			t.Fatalf("make v2 forge dir: %v", err)
+		}
+
+		p = filepath.Join(root, "civ2/forge/Dockerfile.forgev2")
+		if err := os.WriteFile(p, content, 0600); err != nil {
+			t.Fatalf("write v2 forge file: %v", err)
+		}
+
+		g, err := makeForgeGroup(root, buildID, config)
+		if err != nil {
+			t.Fatalf("make forge group: %v", err)
+		}
+
+		if g.Group != "forge" {
+			t.Errorf("got group %q, want %q", g.Group, "forge")
+		}
+		if g.Key != "all-forges" {
+			t.Errorf("got key %q, want %q", g.Key, "all-forges")
+		}
+		if len(g.Steps) != 2 {
+			t.Fatalf("got %d steps, want 1", len(g.Steps))
+		}
+
+		step := g.Steps[0].(map[string]any)
+		want := map[string]any{
+			"label":    "forge",
+			"key":      "forge",
+			"commands": []string{forgeBuilderCommand},
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":         buildID,
+				"RAYCI_TMP_REPO":         config.CITempRepo,
+				"RAYCI_FORGE_DOCKERFILE": "ci/forge/Dockerfile.forge",
+				"RAYCI_FORGE_NAME":       "forge",
+			},
+			"agents": map[string]any{"queue": "builder_queue"},
+		}
+		if !reflect.DeepEqual(step, want) {
+			t.Errorf(
+				"got step 1 %s\n, want %s",
+				jsonString(step),
+				jsonString(want),
+			)
+		}
+
+		step = g.Steps[1].(map[string]any)
+		want = map[string]any{
+			"label":    "forgev2",
+			"key":      "forgev2",
+			"commands": []string{forgeBuilderCommand},
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":         buildID,
+				"RAYCI_TMP_REPO":         config.CITempRepo,
+				"RAYCI_FORGE_DOCKERFILE": "civ2/forge/Dockerfile.forgev2",
+				"RAYCI_FORGE_NAME":       "forgev2",
+			},
+			"agents": map[string]any{"queue": "builder_queue"},
+		}
+		if !reflect.DeepEqual(step, want) {
+			t.Errorf(
+				"got step 2 %s\n, want %s",
+				jsonString(step),
+				jsonString(want),
+			)
+		}
+	})
 }


### PR DESCRIPTION
this is a special type of build jobs where the command line is fixed. it builds a base container with no input in the builder queue, called forges, and allows other runner rules to use these forge containers to run other jobs, such as building containers.

it is only for bootstraping the build process with a standard build job sandbox. forges will not only contain build tools, but not library/application/build target dependencies, and hence does not need input.