### PR TITLE
add a counting writer

### DIFF
--- a/wanda/counting_writer.go
+++ b/wanda/counting_writer.go
@@ -1,0 +1,21 @@
+package wanda
+
+import (
+	"io"
+)
+
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func newCountingWriter(w io.Writer) *countingWriter {
+	return &countingWriter{w: w}
+}
+
+// Write writes to the underlying writer and counts the number of bytes written.
+func (w *countingWriter) Write(buf []byte) (int, error) {
+	n, err := w.w.Write(buf)
+	w.n += int64(n)
+	return n, err
+}

--- a/wanda/counting_writer.go
+++ b/wanda/counting_writer.go
@@ -13,7 +13,8 @@ func newCountingWriter(w io.Writer) *countingWriter {
 	return &countingWriter{w: w}
 }
 
-// Write writes to the underlying writer and counts the number of bytes written.
+// Write implements io.Writer; it writes to the underlying writer and counts
+// the number of bytes written.
 func (w *countingWriter) Write(buf []byte) (int, error) {
 	n, err := w.w.Write(buf)
 	w.n += int64(n)

--- a/wanda/counting_writer_test.go
+++ b/wanda/counting_writer_test.go
@@ -1,0 +1,19 @@
+package wanda
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestCountingWriter(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := newCountingWriter(buf)
+
+	io.WriteString(w, "hello")
+	io.WriteString(w, "world")
+
+	if w.n != 10 {
+		t.Errorf("expected 10 bytes written, got %d", w.n)
+	}
+}


### PR DESCRIPTION
this is required for wrapping a tarball stream, which will be used for providing deterministic context input for a docker image build.

wanda is the name of the new command line tool for building images with fast caches.