### PR TITLE
make tags in base image building deterministic

### DIFF
--- a/ray_ci/build_base_build.sh
+++ b/ray_ci/build_base_build.sh
@@ -2,10 +2,8 @@
 
 set -euo pipefail
 
-export DOCKER_BUILDKIT=1
-
 if [[ "${RAY_REPO_DIR:-}" != "" ]]; then
-  cd "$RAY_REPO_DIR" || true
+  cd "$RAY_REPO_DIR"
 fi
 
 if [[ "${BUILDKITE_COMMIT:-HEAD}" == "HEAD" ]]; then
@@ -13,23 +11,17 @@ if [[ "${BUILDKITE_COMMIT:-HEAD}" == "HEAD" ]]; then
 fi
 echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
 
-ECR_BASE_REPO="${ECR_BASE_REPO:-029272617770.dkr.ecr.us-west-2.amazonaws.com/ci_base_images}"
-
-DOCKER_IMAGE_BASE_TEST=$ECR_BASE_REPO:oss-ci-base_test_$BUILDKITE_COMMIT
-DOCKER_IMAGE_BASE_BUILD=$ECR_BASE_REPO:oss-ci-base_build_$BUILDKITE_COMMIT
-DOCKER_IMAGE_BASE_ML=$ECR_BASE_REPO:oss-ci-base_ml_$BUILDKITE_COMMIT
-
-# DOCKER_IMAGE_BASE_TEST is used as build arg
-export DOCKER_IMAGE_BASE_TEST
 
 echo "--- :docker: Building base dependency image for TESTS :python:"
+
+export DOCKER_BUILDKIT=1
 
 docker build --progress=plain \
   --build-arg REMOTE_CACHE_URL \
   --build-arg BUILDKITE_PULL_REQUEST \
   --build-arg BUILDKITE_COMMIT \
   --build-arg BUILDKITE_PULL_REQUEST_BASE_BRANCH \
-  -t "$DOCKER_IMAGE_BASE_TEST" \
+  -t cr.ray.io/rayproject/oss-ci-base_test \
   -f ci/docker/base.test.Dockerfile .
 
 echo "--- :docker: Building base dependency image for BUILDS :gear:"
@@ -39,8 +31,8 @@ docker build --progress=plain \
   --build-arg BUILDKITE_PULL_REQUEST \
   --build-arg BUILDKITE_COMMIT \
   --build-arg BUILDKITE_PULL_REQUEST_BASE_BRANCH \
-  --build-arg DOCKER_IMAGE_BASE_TEST \
-  -t "$DOCKER_IMAGE_BASE_BUILD" \
+  --build-arg DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test \
+  -t cr.ray.io/rayproject/oss-ci-base_build \
   -f ci/docker/base.build.Dockerfile .
 
 echo "--- :docker: Building base dependency image for ML :airplane:"
@@ -50,8 +42,8 @@ docker build --progress=plain \
   --build-arg BUILDKITE_PULL_REQUEST \
   --build-arg BUILDKITE_COMMIT \
   --build-arg BUILDKITE_PULL_REQUEST_BASE_BRANCH \
-  --build-arg DOCKER_IMAGE_BASE_TEST \
-  -t "$DOCKER_IMAGE_BASE_ML" \
+  --build-arg DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test \
+  -t cr.ray.io/rayproject/oss-ci-base_ml \
   -f ci/docker/base.ml.Dockerfile .
 
 
@@ -73,17 +65,25 @@ else
   BRANCH_NAME="dev"
 fi
 
+ECR_BASE_REPO="${ECR_BASE_REPO:-029272617770.dkr.ecr.us-west-2.amazonaws.com/ci_base_images}"
+DOCKER_IMAGE_BASE_TEST=$ECR_BASE_REPO:oss-ci-base_test_$BUILDKITE_COMMIT
+DOCKER_IMAGE_BASE_BUILD=$ECR_BASE_REPO:oss-ci-base_build_$BUILDKITE_COMMIT
+DOCKER_IMAGE_BASE_ML=$ECR_BASE_REPO:oss-ci-base_ml_$BUILDKITE_COMMIT
+
 DOCKER_IMAGE_TAG_TEST="${ECR_BASE_REPO}:oss-ci-base_test_latest_${BRANCH_NAME}"
 DOCKER_IMAGE_TAG_BUILD="${ECR_BASE_REPO}:oss-ci-base_build_latest_${BRANCH_NAME}"
 DOCKER_IMAGE_TAG_ML="${ECR_BASE_REPO}:oss-ci-base_ml_latest_${BRANCH_NAME}"
 
 echo "--- Push ci-base_test"
+docker tag cr.ray.io/rayproject/oss-ci-base_test "$DOCKER_IMAGE_BASE_TEST"
 docker push "$DOCKER_IMAGE_BASE_TEST"
 
 echo "--- Push ci-base_build"
+docker tag cr.ray.io/rayproject/oss-ci-base_build "$DOCKER_IMAGE_BASE_BUILD"
 docker push "$DOCKER_IMAGE_BASE_BUILD"
 
 echo "--- Push ci-base_ml"
+docker tag cr.ray.io/rayproject/oss-ci-base_ml "$DOCKER_IMAGE_BASE_ML"
 docker push "$DOCKER_IMAGE_BASE_ML"
 
 echo "--- Tagging aliases"


### PR DESCRIPTION
make the input for base image picking irrelevant to the build commit on local build. this will make the build args part of the input deterministic and cachable.

the `BUILDKITE_PULL_REQUEST` and `BUILDKITE_COMMIT` will also be removed from follow up changes.