### PR TITLE
[wanda] 1/ add tar meta and tests

### DIFF
--- a/wanda/tar_meta.go
+++ b/wanda/tar_meta.go
@@ -1,0 +1,20 @@
+package wanda
+
+import (
+	"os"
+)
+
+type tarMeta struct {
+	Mode    int64
+	UserID  int
+	GroupID int
+}
+
+func tarMetaFromFileInfo(info os.FileInfo) *tarMeta {
+	const rootUser = 0
+	return &tarMeta{
+		Mode:    int64(info.Mode()) & 0777,
+		UserID:  rootUser,
+		GroupID: rootUser,
+	}
+}

--- a/wanda/tar_meta_test.go
+++ b/wanda/tar_meta_test.go
@@ -1,17 +1,18 @@
 package wanda
 
 import (
+	"testing"
+
 	"fmt"
 	"os"
 	"path/filepath"
-	"testing"
 )
 
 func TestTarMetaFromFileInfo(t *testing.T) {
 	tmp := t.TempDir()
 
 	for _, mod := range []int64{
-		0775, // bazel's sandbox does not support 777.
+		0755, // bazel's sandbox umask does not support 777.
 		0644,
 		0600,
 		0400,

--- a/wanda/tar_meta_test.go
+++ b/wanda/tar_meta_test.go
@@ -1,0 +1,42 @@
+package wanda
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTarMetaFromFileInfo(t *testing.T) {
+	tmp := t.TempDir()
+
+	for _, mod := range []int64{
+		0775, // bazel's sandbox does not support 777.
+		0644,
+		0600,
+		0400,
+		0700,
+	} {
+		path := filepath.Join(tmp, fmt.Sprintf("file-%d", mod))
+		data := []byte(fmt.Sprintf("%d", mod))
+		if err := os.WriteFile(path, data, os.FileMode(mod)); err != nil {
+			t.Fatalf("write file %q: %v", path, err)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %q: %v", path, err)
+		}
+
+		meta := tarMetaFromFileInfo(info)
+		if meta.Mode != mod {
+			t.Errorf("got mode %o, want %o", meta.Mode, mod)
+		}
+		if meta.GroupID != 0 {
+			t.Errorf("got group id %d, want 0", meta.GroupID)
+		}
+		if meta.UserID != 0 {
+			t.Errorf("got user id %d, want 0", meta.UserID)
+		}
+	}
+}


### PR DESCRIPTION
used to capturing file mode of build input files, but unifying all user id and group id to root, so that the result is deterministic.