### PR TITLE
[wanda] 0/ add digest utility to capture digest strings

### DIFF
--- a/wanda/digest.go
+++ b/wanda/digest.go
@@ -1,0 +1,17 @@
+package wanda
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+)
+
+func sha256DigestString(h hash.Hash) string {
+	return fmt.Sprintf("sha256:%x", h.Sum(nil))
+}
+
+func sha256Digest(bs []byte) string {
+	h := sha256.New()
+	h.Write(bs)
+	return sha256DigestString(h)
+}

--- a/wanda/digest_test.go
+++ b/wanda/digest_test.go
@@ -1,0 +1,17 @@
+package wanda
+
+import (
+	"testing"
+)
+
+func TestSha256Digest(t *testing.T) {
+	const msg1 = "hello world"
+	const msg2 = "Hello world!"
+
+	d1 := sha256Digest([]byte(msg1))
+	d2 := sha256Digest([]byte(msg2))
+
+	if d1 == d2 {
+		t.Errorf("got same digest after adding file: %q vs %q", d1, d2)
+	}
+}


### PR DESCRIPTION
generates digests with `"sha256:"` prefix.