### PR TITLE
config: add a cache readonly mark for PR configs

### DIFF
--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -59,10 +59,6 @@ const rayCIECR = "029272617770.dkr.ecr.us-west-2.amazonaws.com"
 
 const rayBazelBuildCache = "https://bazel-cache-dev.s3.us-west-2.amazonaws.com"
 
-var rayCIEnv = map[string]string{
-	"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
-}
-
 var defaultForgeDirs = []string{".buildkite/forge", "ci/forge", "ci/v2/forge"}
 
 var branchPipelineConfig = &config{
@@ -91,7 +87,9 @@ var branchPipelineConfig = &config{
 
 	ForgeDirs: defaultForgeDirs,
 
-	Env: rayCIEnv,
+	Env: map[string]string{
+		"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
+	},
 }
 
 var prPipelineConfig = &config{
@@ -123,7 +121,10 @@ var prPipelineConfig = &config{
 
 	ForgeDirs: defaultForgeDirs,
 
-	Env: rayCIEnv,
+	Env: map[string]string{
+		"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
+		"BUILDKITE_CACHE_READONLY":  "true",
+	},
 }
 
 func ciDefaultConfig(envs Envs) *config {


### PR DESCRIPTION
we will stop using "if it is a PR" for checking.

Rather, simply use if it runs on the premerge pipeline or the postmerge pipeline. this will enable people to manually run and also for insiders to run on non-master but still has the power to write to caching infra and/or perform releases.