### PR TITLE
[raycicmd] pipe through RAYCI_BRANCH env var

### DIFF
--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -14,7 +14,7 @@ type converter struct {
 	envMap map[string]string
 }
 
-func newConverter(config *config, buildID string) *converter {
+func newConverter(config *config, buildID, rayciBranch string) *converter {
 	c := &converter{
 		config:  config,
 		buildID: buildID,
@@ -26,6 +26,9 @@ func newConverter(config *config, buildID string) *converter {
 	envMap["RAYCI_BUILD_ID"] = buildID
 	envMap["RAYCI_WORK_REPO"] = config.CIWorkRepo
 	envMap["RAYCI_TEMP"] = c.ciTempForBuild
+	if rayciBranch != "" {
+		envMap["RAYCI_BRANCH"] = rayciBranch
+	}
 	if config.ForgePrefix != "" {
 		envMap["RAYCI_FORGE_PREFIX"] = config.ForgePrefix
 	}

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -43,7 +43,7 @@ func TestConvertPipelineStep(t *testing.T) {
 		Env: map[string]string{
 			"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 		},
-	}, buildID)
+	}, buildID, "beta")
 
 	for _, test := range []struct {
 		in  map[string]any
@@ -61,6 +61,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_BRANCH":              "beta",
 			},
 		},
 	}, {
@@ -86,6 +87,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_BRANCH":              "beta",
 			},
 		},
 	}, {
@@ -103,6 +105,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_BRANCH":              "beta",
 
 				"RAYCI_WANDA_FILE": "ci/forge.wanda.yaml",
 				"RAYCI_WANDA_NAME": "forge",
@@ -197,7 +200,7 @@ func TestConvertPipelineStep_priority(t *testing.T) {
 		},
 
 		RunnerPriority: 1,
-	}, buildID)
+	}, buildID, "")
 
 	g := &pipelineGroup{
 		Group: "fancy",
@@ -231,7 +234,7 @@ func TestConvertPipelineGroup(t *testing.T) {
 		CITemp:          "s3://ci-temp/",
 
 		RunnerQueues: map[string]string{"default": "runner"},
-	}, "buildid")
+	}, "buildid", "")
 
 	g := &pipelineGroup{
 		Group: "fancy",

--- a/raycicmd/main.go
+++ b/raycicmd/main.go
@@ -89,7 +89,9 @@ func Main(args []string, envs Envs) error {
 		return fmt.Errorf("make build id: %w", err)
 	}
 
-	pipeline, err := makePipeline(flags.RepoDir, config, buildID)
+	rayciBranch, _ := envs.Lookup("RAYCI_BRANCH")
+
+	pipeline, err := makePipeline(flags.RepoDir, config, buildID, rayciBranch)
 	if err != nil {
 		return fmt.Errorf("make pipeline: %w", err)
 	}

--- a/raycicmd/make.go
+++ b/raycicmd/make.go
@@ -61,12 +61,12 @@ func parsePipelineFile(file string) (*pipelineGroup, error) {
 	return g, nil
 }
 
-func makePipeline(repoDir string, config *config, buildID string) (
+func makePipeline(repoDir string, config *config, buildID, rayciBranch string) (
 	*bkPipeline, error,
 ) {
 	pl := new(bkPipeline)
 
-	c := newConverter(config, buildID)
+	c := newConverter(config, buildID, rayciBranch)
 
 	// Build steps that build the forge images.
 

--- a/raycicmd/make_test.go
+++ b/raycicmd/make_test.go
@@ -191,7 +191,7 @@ func TestMakePipeline(t *testing.T) {
 
 	buildID := "fakebuild"
 
-	got, err := makePipeline(tmp, config, buildID)
+	got, err := makePipeline(tmp, config, buildID, "")
 	if err != nil {
 		t.Fatalf("makePipeline: %v", err)
 	}


### PR DESCRIPTION
so that `run_wanda.sh` can load and compile from the same branch.

useful for debugging, and required for e2e testing on rayci's own pipeline.