### PR TITLE
[legacy bootstrap] unify to BUILDKITE_BAZEL_CACHE_URL

### DIFF
--- a/ray_ci/build_base_build.sh
+++ b/ray_ci/build_base_build.sh
@@ -23,6 +23,8 @@ echo "--- :docker: Building base dependency image for TESTS :python:"
 
 export DOCKER_BUILDKIT=1
 
+export BUILDKITE_BAZEL_CACHE_URL="${REMOTE_CACHE_URL}"
+
 if [[ -f ci/docker/base.test.wanda.yaml ]]; then
   "${WANDA[@]}" ci/docker/base.test.wanda.yaml
 else


### PR DESCRIPTION
new rayci wanda steps only populates `BUILDKITE_BAZEL_CACHE_URL`, but not `REMOTE_CACHE_URL`