### PR TITLE
add a simple release script to build release bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tags
 /.vscode
+/_release
 .DS_Store
 
 __pycache__

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+mkdir -p _release
+rm -f _release/*
+
+RAYCI_OS="$(go env GOOS)"
+RAYCI_ARCH="$(go env GOARCH)"
+
+go build -trimpath -o "_release/rayci-${RAYCI_OS}-${RAYCI_ARCH}" .
+go build -trimpath -o "_release/wanda-${RAYCI_OS}-${RAYCI_ARCH}" ./wanda/wanda


### PR DESCRIPTION
for releasing rayci and wanda binaries.

after we have more stable releases, we can just download bins rather than build from source all the time.