### PR TITLE
[ci] use small runner for launching and legacy

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ steps:
     commands:
       - RAYCI_BRANCH="$${BUILDKITE_COMMIT}" /bin/bash run_rayci.sh -upload
     agents:
-      queue: "runner_queue_pr"
+      queue: "runner_queue_small_pr"
 
   - label: "legacy ray_ci python test"
     commands:
@@ -11,7 +11,7 @@ steps:
       - pip3 install pytest click pyyaml
       - (cd ray_ci; python3 -m pytest -v .)
     agents:
-      queue: "runner_queue_pr"
+      queue: "runner_queue_small_pr"
     plugins:
       - docker#v5.7.0:
           image: amazonlinux:2


### PR DESCRIPTION
don't use large ones.