### PR TITLE
[legacy] add pipeline id and slug to launcher

### DIFF
--- a/ray_ci/step_linux.json
+++ b/ray_ci/step_linux.json
@@ -33,6 +33,8 @@
                     "BUILDKITE_BUILD_ID",
                     "BUILDKITE_PARALLEL_JOB",
                     "BUILDKITE_PARALLEL_JOB_COUNT",
+                    "BUILDKITE_PIPELINE_SLUG",
+                    "BUILDKITE_PIPELINE_ID",
                     "BUILDKITE_MESSAGE",
                     "BUILDKITE_BUILD_NUMBER",
                     "PS4"


### PR DESCRIPTION
so that checks that uses pipeline id won't read empty string.