### PR TITLE
[ci][coverage] compute coverage for core + serverless tests

### DIFF
--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -143,6 +143,8 @@ var prPipelineConfig = &config{
 	Env: map[string]string{
 		"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
 		"BUILDKITE_CACHE_READONLY":  "true",
+		"RAYCI_PYTHON_AFFECTED":    os.Getenv("RAY_CI_PYTHON_AFFECTED"),
+		"RAYCI_DASHBOARD_AFFECTED": os.Getenv("RAY_CI_DASHBOARD_AFFECTED"),
 	},
 }
 

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -16,4 +16,5 @@ export GOPRIVATE="github.com/ray-project/rayci"
 
 echo "--- Run rayci"
 
+export $(python ci/pipeline/determine_tests_to_run.py)
 exec "$GOPATH/bin/rayci" "$@"


### PR DESCRIPTION
Compute coverage info for ray/python changes, so that we can turn off core + serverless tests for non-core changes. These tests deem to be quite flaky, and we should let core fix them without affecting other team.

Test:
- Run on dev pipeline, look great: https://buildkite.com/ray-project/dev/builds/53