### PR TITLE
[rayci][coverage] determine core changes

### DIFF
--- a/raycicmd/build_info_test.go
+++ b/raycicmd/build_info_test.go
@@ -41,3 +41,11 @@ func TestGitCommit(t *testing.T) {
 		t.Errorf("gitCommit: got %q, want %q", got, want)
 	}
 }
+
+func TestGitDiff(t *testing.T) {
+	env := newEnvsMap(map[string]string{})
+	got := gitDiff(env)
+	if len(got) != 0 {
+		t.Errorf("gitDiff: got %v, want empty", got)
+	}
+}

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -141,10 +141,24 @@ func TestConvertPipelineStep(t *testing.T) {
 			"wait": nil, "continue_on_failure": true,
 			"depends_on": "dep", "if": "false",
 		},
+	}, {
+		in: map[string]any{
+			"team": "core",
+		},
+		out: nil,
 	}} {
-		got, err := c.convertPipelineStep(test.in)
+		got, err := c.convertPipelineStep(test.in, []string{"python/ray/air/abc.py"})
 		if err != nil {
 			t.Errorf("convertPipelineStep %+v: %v", test.in, err)
+			continue
+		}
+		if test.out == nil {
+			if got != nil {
+				t.Errorf(
+					"convertPipelineStep %+v: got %+v, want %+v",
+					test.in, got, test.out,
+				)
+			}
 			continue
 		}
 
@@ -239,7 +253,7 @@ func TestConvertPipelineStep_priority(t *testing.T) {
 			{"commands": []string{"default priority"}},
 		},
 	}
-	bk, err := c.convertPipelineGroup(g)
+	bk, err := c.convertPipelineGroup(g, []string{})
 	if err != nil {
 		t.Fatalf("convertPipelineGroup: %v", err)
 	}
@@ -278,7 +292,7 @@ func TestConvertPipelineGroup(t *testing.T) {
 			{"commands": []string{"echo 1"}},
 		},
 	}
-	bk, err := c.convertPipelineGroup(g)
+	bk, err := c.convertPipelineGroup(g, []string{})
 	if err != nil {
 		t.Fatalf("convertPipelineGroup: %v", err)
 	}

--- a/raycicmd/coverage.go
+++ b/raycicmd/coverage.go
@@ -1,0 +1,33 @@
+package raycicmd
+
+import (
+	"strings"
+)
+
+func affectedByChange(team string, changes []string) bool {
+	if len(changes) == 0 {
+		// not a pr step, always run
+		return true
+	}
+	if team != "core" {
+		// not a core team step, always run
+		return true
+	}
+	for _, file := range changes {
+		if isCoreChange(file) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCoreChange(file string) bool {
+	return strings.HasPrefix(file, "dashboard") ||
+		(strings.HasPrefix(file, "python/") &&
+			!strings.HasPrefix(file, "python/ray/air/") &&
+			!strings.HasPrefix(file, "python/ray/data/") &&
+			!strings.HasPrefix(file, "python/ray/workflow/") &&
+			!strings.HasPrefix(file, "python/ray/tune/") &&
+			!strings.HasPrefix(file, "python/ray/train/") &&
+			!strings.HasPrefix(file, "python/ray/serve/"))
+}

--- a/raycicmd/coverage_test.go
+++ b/raycicmd/coverage_test.go
@@ -1,0 +1,39 @@
+package raycicmd
+
+import (
+	"testing"
+)
+
+func TestAnyCoreChange(t *testing.T) {
+	isEmptyCoreChange := affectedByChange("core", []string{})
+	if !isEmptyCoreChange {
+		t.Errorf("affectedByChange: got %t, want %t", isEmptyCoreChange, true)
+	}
+	isCoreCoreChange := affectedByChange("core", []string{"python/abc.py", "python/ray/air/abc.py"})
+	if !isCoreCoreChange {
+		t.Errorf("affectedByChange: got %t, want %t", isCoreCoreChange, true)
+	}
+	isAirCoreChange := affectedByChange("core", []string{"python/ray/air/abc.py"})
+	if isAirCoreChange {
+		t.Errorf("affectedByChange: got %t, want %t", isAirCoreChange, false)
+	}
+	isNoOwnerChange := affectedByChange("", []string{"python/abc.py", "python/ray/air/abc.py"})
+	if !isNoOwnerChange {
+		t.Errorf("affectedByChange: got %t, want %t", isNoOwnerChange, true)
+	}
+}
+
+func TestIsCoreChange(t *testing.T) {
+	isCoreCoreChange := isCoreChange("python/abc.py")
+	if !isCoreCoreChange {
+		t.Errorf("isCoreChange: got %t, want %t", isCoreCoreChange, true)
+	}
+	isDashboardCoreChange := isCoreChange("dashboard/abc.py")
+	if !isDashboardCoreChange {
+		t.Errorf("isCoreChange: got %t, want %t", isDashboardCoreChange, true)
+	}
+	isAirCoreChange := isCoreChange("python/ray/air/abc.py")
+	if isAirCoreChange {
+		t.Errorf("isCoreChange: got %t, want %t", isAirCoreChange, false)
+	}
+}

--- a/raycicmd/main.go
+++ b/raycicmd/main.go
@@ -91,11 +91,13 @@ func Main(args []string, envs Envs) error {
 
 	rayciBranch, _ := envs.Lookup("RAYCI_BRANCH")
 	commit := gitCommit(envs)
+	diff := gitDiff(envs)
 
 	info := &buildInfo{
 		BuildID:     buildID,
 		RayCIBranch: rayciBranch,
 		GitCommit:   commit,
+		GitDiff:     diff,
 	}
 
 	pipeline, err := makePipeline(flags.RepoDir, config, info)

--- a/raycicmd/make.go
+++ b/raycicmd/make.go
@@ -102,7 +102,7 @@ func makePipeline(repoDir string, config *config, info *buildInfo) (
 				return nil, fmt.Errorf("parse pipeline file %s: %w", file, err)
 			}
 
-			bkGroup, err := c.convertPipelineGroup(g)
+			bkGroup, err := c.convertPipelineGroup(g, info.GitDiff)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"convert pipeline group %s: %w", file, err,

--- a/raycicmd/rayci_pipeline.go
+++ b/raycicmd/rayci_pipeline.go
@@ -14,11 +14,11 @@ var (
 	commandStepAllowedKeys = []string{
 		"command", "commands", "priority", "parallelism", "if",
 		"label", "name", "key", "depends_on", "soft_fail", "matrix",
-		"instance_type", "queue", "job_env",
+		"instance_type", "queue", "job_env", "team",
 	}
 	wandaStepAllowedKeys = []string{"name", "wanda", "depends_on"}
 
 	commandStepDropKeys = []string{
-		"instance_type", "queue", "job_env",
+		"instance_type", "queue", "job_env", "team",
 	}
 )


### PR DESCRIPTION
Determine whether the set of changes affect core team. We introduce a new step key call 'team', to identify both ownership as well as an granularity level of coverage.

Currently I only implement coverage for core team; all non-core steps will always run regardless of changes. Also non-pr steps will also always run.

Test:
- CI
- None-core-change, core and serverless tests are skipped: https://buildkite.com/ray-project/dev/builds/62
- Core change, everything runs: https://buildkite.com/ray-project/dev/builds/64