### PR TITLE
[wanda] change cache prefix to `z-`

### DIFF
--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -95,7 +95,7 @@ func (f *Forge) cacheTag(inputDigest string) string {
 	if _, d, ok := strings.Cut(inputDigest, ":"); ok {
 		inputDigest = d
 	}
-	return fmt.Sprintf("%s:c-%s", f.workRepo(), inputDigest)
+	return fmt.Sprintf("%s:z-%s", f.workRepo(), inputDigest)
 }
 
 func (f *Forge) resolveBases(froms []string) (map[string]*imageSource, error) {


### PR DESCRIPTION
so that we can use prefix for more aggressive ecr tag garbage collection for non-cache, temp tags.