### PR TITLE
[rayci][coverage] filter steps by tag

### DIFF
--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -39,9 +39,14 @@ type config struct {
 	// build jobs from buildkite hooks.
 	HookEnvKeys []string `yaml:"hook_env_keys"`
 
-	// Command to populate the buildkite step tags. When this command is specified,
-	// a buildkite step is skipped if it is tagged by something that is not returned
-	// by this command.
+	// Command to populate the buildkite step tags. When this command is
+	// specified, a buildkite step is skipped if it is tagged by something that
+	// is not returned by this command.
+	//
+	// If the first arg (the binary) starts with "./", then it is treated as
+	// a file path relative the repsitory root, and it will be checked if the
+	// file exists. If the file does not exist, then the command is ignored
+	// and all steps will be executed.
 	TagFilterCommand []string `yaml:"tag_filter_command"`
 }
 

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -158,12 +158,7 @@ var prPipelineConfig = &config{
 
 	HookEnvKeys: []string{"RAYCI_CHECKOUT_DIR"},
 
-	TagFilterCommand: []string{
-		"python",
-		"ci/pipeline/determine_tests_to_run.py",
-		"--output",
-		"rayci_tags",
-	},
+	TagFilterCommand: []string{"./ci/ci_tags_from_change.sh"},
 }
 
 func ciDefaultConfig(envs Envs) *config {

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -38,6 +38,11 @@ type config struct {
 	// HookEnvKeys is the list of environment variable keys to pass into
 	// build jobs from buildkite hooks.
 	HookEnvKeys []string `yaml:"hook_env_keys"`
+
+	// Command to populate the buildkite step tags. When this command is specified,
+	// a buildkite step is skipped if it is tagged by something that is not returned
+	// by this command.
+	TagFilterCommand []string `yaml:"tag_filter_command"`
 }
 
 func builderAgent(config *config) string {
@@ -152,6 +157,13 @@ var prPipelineConfig = &config{
 	},
 
 	HookEnvKeys: []string{"RAYCI_CHECKOUT_DIR"},
+
+	TagFilterCommand: []string{
+		"python",
+		"ci/pipeline/determine_tests_to_run.py",
+		"--output",
+		"rayci_tags",
+	},
 }
 
 func ciDefaultConfig(envs Envs) *config {

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -172,7 +172,7 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 	return result, nil
 }
 
-func (c *converter) convertPipelineGroup(g *pipelineGroup, tagFilter *tagFilter) (
+func (c *converter) convertPipelineGroup(g *pipelineGroup, filter *tagFilter) (
 	*bkPipelineGroup, error,
 ) {
 	bkGroup := &bkPipelineGroup{
@@ -183,7 +183,7 @@ func (c *converter) convertPipelineGroup(g *pipelineGroup, tagFilter *tagFilter)
 	for _, step := range g.Steps {
 		// filter steps by tags
 		if stepTags, ok := step["tags"]; ok {
-			if !tagFilter.hit(fieldToStringList(stepTags)) {
+			if !filter.hit(fieldToStringList(stepTags)) {
 				continue
 			}
 		}

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -172,19 +172,6 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 	return result, nil
 }
 
-func doesIntersect(arr1 []string, arr2 []interface{}) bool {
-	set := make(map[string]bool)
-	for _, s := range arr1 {
-		set[s] = true
-	}
-	for _, s := range arr2 {
-		if set[s.(string)] {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *converter) convertPipelineGroup(g *pipelineGroup, tagFilter *tagFilter) (
 	*bkPipelineGroup, error,
 ) {
@@ -195,11 +182,10 @@ func (c *converter) convertPipelineGroup(g *pipelineGroup, tagFilter *tagFilter)
 
 	for _, step := range g.Steps {
 		// filter steps by tags
-		stepTags, ok := step["tags"].([]interface{})
-		filterTags := tagFilter.tags
-		runAll := tagFilter.runAll
-		if ok && !runAll && !doesIntersect(filterTags, stepTags) {
-			continue
+		if stepTags, ok := step["tags"]; ok {
+			if !tagFilter.hit(fieldToStringList(stepTags)) {
+				continue
+			}
 		}
 
 		// convert step to buildkite step

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -291,7 +291,8 @@ func TestConvertPipelineGroup(t *testing.T) {
 			{"commands": []string{"echo 2"}, "tags": []interface{}{"bar"}},
 		},
 	}
-	bk, err := c.convertPipelineGroup(g, &tagFilter{tags: []string{"foo"}, runAll: false})
+
+	bk, err := c.convertPipelineGroup(g, &tagFilter{tags: []string{"foo"}})
 	if err != nil {
 		t.Fatalf("convertPipelineGroup: %v", err)
 	}
@@ -301,32 +302,5 @@ func TestConvertPipelineGroup(t *testing.T) {
 	}
 	if len(bk.Steps) != 3 {
 		t.Errorf("convertPipelineGroup: got %d steps, want 3", len(bk.Steps))
-	}
-}
-
-func TestDoesIntersect(t *testing.T) {
-	for _, test := range []struct {
-		in01 []string
-		in02 []interface{}
-		out  bool
-	}{{
-		in01: []string{"foo", "bar"},
-		in02: []interface{}{"foo", "w00t"},
-		out:  true,
-	}, {
-		in01: []string{"foo", "bar"},
-		in02: []interface{}{"hi", "w00t"},
-		out:  false,
-	}, {
-		in01: []string{},
-		in02: []interface{}{},
-		out:  false,
-	}} {
-		if got := doesIntersect(test.in01, test.in02); got != test.out {
-			t.Errorf(
-				"runTagFilter %+v, %+v: got %+v, want %+v",
-				test.in01, test.in02, got, test.out,
-			)
-		}
 	}
 }

--- a/raycicmd/make.go
+++ b/raycicmd/make.go
@@ -4,17 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
 )
-
-type tagFilter struct {
-	tags   []string
-	runAll bool
-}
 
 func isRayCIYaml(p string) bool {
 	if strings.HasSuffix(p, ".rayci.yaml") {
@@ -65,20 +59,6 @@ func parsePipelineFile(file string) (*pipelineGroup, error) {
 	}
 
 	return g, nil
-}
-
-func runTagFilterCommand(tagFilterCommand []string) (*tagFilter, error) {
-	if len(tagFilterCommand) == 0 {
-		return &tagFilter{tags: []string{}, runAll: true}, nil
-	}
-	// TODO: put the execution in an unprivileged sandbox
-	cmd := exec.Command(tagFilterCommand[0], tagFilterCommand[1:]...)
-	filters, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("tag filter script: %w", err)
-	}
-
-	return &tagFilter{tags: strings.Fields(string(filters)), runAll: false}, nil
 }
 
 func makePipeline(repoDir string, config *config, info *buildInfo) (

--- a/raycicmd/make_test.go
+++ b/raycicmd/make_test.go
@@ -142,29 +142,6 @@ func TestParsePipelineFile(t *testing.T) {
 	})
 }
 
-func TestRunTagFilterCommand(t *testing.T) {
-	for _, test := range []struct {
-		in  []string
-		out *tagFilter
-	}{{
-		in:  []string{"echo", "RAYCI_COVERAGE"},
-		out: &tagFilter{tags: []string{"RAYCI_COVERAGE"}, runAll: false},
-	}, {
-		in:  []string{},
-		out: &tagFilter{tags: []string{}, runAll: true},
-	}, {
-		in:  []string{"exit", "1"},
-		out: nil,
-	}} {
-		if got, _ := runTagFilterCommand(test.in); !reflect.DeepEqual(got, test.out) {
-			t.Errorf(
-				"runTagFilter %+v: got %+v, want %+v",
-				test.in, got, test.out,
-			)
-		}
-	}
-}
-
 func TestMakePipeline(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/raycicmd/make_test.go
+++ b/raycicmd/make_test.go
@@ -142,6 +142,29 @@ func TestParsePipelineFile(t *testing.T) {
 	})
 }
 
+func TestRunTagFilterCommand(t *testing.T) {
+	for _, test := range []struct {
+		in  []string
+		out *tagFilter
+	}{{
+		in:  []string{"echo", "RAYCI_COVERAGE"},
+		out: &tagFilter{tags: []string{"RAYCI_COVERAGE"}, runAll: false},
+	}, {
+		in:  []string{},
+		out: &tagFilter{tags: []string{}, runAll: true},
+	}, {
+		in:  []string{"exit", "1"},
+		out: nil,
+	}} {
+		if got, _ := runTagFilterCommand(test.in); !reflect.DeepEqual(got, test.out) {
+			t.Errorf(
+				"runTagFilter %+v: got %+v, want %+v",
+				test.in, got, test.out,
+			)
+		}
+	}
+}
+
 func TestMakePipeline(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/raycicmd/rayci_pipeline.go
+++ b/raycicmd/rayci_pipeline.go
@@ -14,11 +14,11 @@ var (
 	commandStepAllowedKeys = []string{
 		"command", "commands", "priority", "parallelism", "if",
 		"label", "name", "key", "depends_on", "soft_fail", "matrix",
-		"instance_type", "queue", "job_env",
+		"instance_type", "queue", "job_env", "tags",
 	}
 	wandaStepAllowedKeys = []string{"name", "wanda", "depends_on"}
 
 	commandStepDropKeys = []string{
-		"instance_type", "queue", "job_env",
+		"instance_type", "queue", "job_env", "tags",
 	}
 )

--- a/raycicmd/tag_filter.go
+++ b/raycicmd/tag_filter.go
@@ -1,0 +1,46 @@
+package raycicmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type tagFilter struct {
+	tags   []string
+	runAll bool
+}
+
+func intersects(set1, set2 []string) bool {
+	set := make(map[string]struct{})
+	for _, s := range set1 {
+		set[s] = struct{}{}
+	}
+	for _, s := range set2 {
+		if _, hit := set[s]; hit {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *tagFilter) hit(tags []string) bool {
+	if f.runAll {
+		return true
+	}
+	return intersects(f.tags, tags)
+}
+
+func runTagFilterCommand(tagFilterCommand []string) (*tagFilter, error) {
+	if len(tagFilterCommand) == 0 {
+		return &tagFilter{runAll: true}, nil
+	}
+	// TODO: put the execution in an unprivileged sandbox
+	cmd := exec.Command(tagFilterCommand[0], tagFilterCommand[1:]...)
+	filters, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("tag filter script: %w", err)
+	}
+
+	return &tagFilter{tags: strings.Fields(string(filters))}, nil
+}

--- a/raycicmd/tag_filter_test.go
+++ b/raycicmd/tag_filter_test.go
@@ -40,11 +40,17 @@ func TestTagFilter(t *testing.T) {
 		cmd:  []string{"echo", "RAYCI_COVERAGE"},
 		want: &tagFilter{tags: []string{"RAYCI_COVERAGE"}},
 	}, {
+		cmd:  []string{"echo", "\t  \n  \t"},
+		want: &tagFilter{},
+	}, {
 		cmd:  []string{},
-		want: &tagFilter{runAll: true},
+		want: runAllTags,
 	}, {
 		cmd:     []string{"exit", "1"},
 		wantErr: true,
+	}, {
+		cmd:  []string{"./local-not-exist.sh"},
+		want: runAllTags,
 	}} {
 		got, err := runTagFilterCommand(test.cmd)
 		if test.wantErr {

--- a/raycicmd/tag_filter_test.go
+++ b/raycicmd/tag_filter_test.go
@@ -1,0 +1,67 @@
+package raycicmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIntersects(t *testing.T) {
+	for _, test := range []struct {
+		set1 []string
+		set2 []string
+		want bool
+	}{{
+		set1: []string{"foo", "bar"},
+		set2: []string{"foo", "w00t"},
+		want: true,
+	}, {
+		set1: []string{"foo", "bar"},
+		set2: []string{"hi", "w00t"},
+		want: false,
+	}, {
+		set1: []string{},
+		set2: []string{},
+		want: false,
+	}} {
+		if got := intersects(test.set1, test.set2); got != test.want {
+			t.Errorf(
+				"intersects %+v, %+v: got %+v, want %+v",
+				test.set1, test.set2, got, test.want,
+			)
+		}
+	}
+}
+func TestTagFilter(t *testing.T) {
+	for _, test := range []struct {
+		cmd     []string
+		want    *tagFilter
+		wantErr bool
+	}{{
+		cmd:  []string{"echo", "RAYCI_COVERAGE"},
+		want: &tagFilter{tags: []string{"RAYCI_COVERAGE"}},
+	}, {
+		cmd:  []string{},
+		want: &tagFilter{runAll: true},
+	}, {
+		cmd:     []string{"exit", "1"},
+		wantErr: true,
+	}} {
+		got, err := runTagFilterCommand(test.cmd)
+		if test.wantErr {
+			if err == nil {
+				t.Errorf("run %q: want error, got nil", test.cmd)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("run %q: %s", test.cmd, err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf(
+				"run %q: got %+v, want %+v",
+				test.cmd, got, test.want,
+			)
+		}
+	}
+}

--- a/raycicmd/util.go
+++ b/raycicmd/util.go
@@ -66,3 +66,26 @@ func checkStepKeys(m map[string]any, allowed []string) error {
 	}
 	return nil
 }
+
+func fieldToStringList(v any) []string {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		var list []string
+		list = append(list, v...)
+		return list
+	case []any:
+		var list []string
+		for _, item := range v {
+			if str, ok := item.(string); ok {
+				list = append(list, str)
+			}
+		}
+		return list
+	case string:
+		return []string{v}
+	default:
+		return nil
+	}
+}

--- a/raycicmd/util_test.go
+++ b/raycicmd/util_test.go
@@ -190,3 +190,23 @@ func TestCheckStepKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldToStringList(t *testing.T) {
+	for _, test := range []struct {
+		in   any
+		want []string
+	}{
+		{nil, nil},
+		{"hello", []string{"hello"}},
+		{[]string{"hello", "world"}, []string{"hello", "world"}},
+		{[]any{"hello", "world"}, []string{"hello", "world"}},
+		{[]any{"hello", 42}, []string{"hello"}},
+	} {
+		got := fieldToStringList(test.in)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("fieldToStringList(%v): got %v, want %v",
+				test.in, got, test.want,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Allow rayci to run an arbitrary shell script that outputs a list of tags. This list of tags will be used to filter steps that are tagged with certain tags.

Test:
- CI
- skip core/serverless https://buildkite.com/ray-project/dev/builds/74
- run everything: https://buildkite.com/ray-project/dev/builds/75