### PR TITLE
[wanda] add env var expansion in wanda spec file

### DIFF
--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -3,6 +3,7 @@ package wanda
 import (
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,6 +22,9 @@ func Build(specFile string, config *ForgeConfig) error {
 	if err != nil {
 		return fmt.Errorf("parse spec file: %w", err)
 	}
+
+	// Expand env variable.
+	spec = spec.expandVar(os.LookupEnv)
 
 	forge, err := NewForge(config)
 	if err != nil {

--- a/wanda/spec.go
+++ b/wanda/spec.go
@@ -40,3 +40,86 @@ func parseSpecFile(f string) (*Spec, error) {
 
 	return spec, nil
 }
+
+type lookupFunc func(string) (string, bool)
+
+func expandVar(s string, lookup lookupFunc) string {
+	buf := new(bytes.Buffer)
+	inName := false
+	nameStart := 0
+
+	replace := func(k string) string {
+		if v, ok := lookup(k); ok {
+			return v
+		}
+		return "$" + k
+	}
+
+	for i, r := range s {
+		if !inName {
+			if r == '$' {
+				inName = true
+				nameStart = i + 1
+			} else {
+				buf.WriteRune(r)
+			}
+		} else {
+			if r == '$' {
+				if nameStart == i {
+					// Name is empty, this is $$
+					buf.WriteRune('$')
+					inName = false
+					continue
+				}
+			}
+			if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' {
+				continue
+			}
+			if r == '_' {
+				continue
+			}
+			if r >= '0' && r <= '9' && i > nameStart {
+				continue
+			}
+
+			buf.WriteString(replace(s[nameStart:i]))
+			if r == '$' {
+				// keep inName as true
+				nameStart = i + 1
+			} else {
+				inName = false
+				buf.WriteRune(r)
+			}
+		}
+	}
+
+	if inName {
+		buf.WriteString(replace(s[nameStart:]))
+	}
+
+	return buf.String()
+}
+
+func stringsExpanVar(slice []string, lookup lookupFunc) []string {
+	if len(slice) == 0 {
+		return nil
+	}
+	result := make([]string, len(slice))
+	for i, s := range slice {
+		result[i] = expandVar(s, lookup)
+	}
+	return result
+}
+
+func (s *Spec) expandVar(lookup lookupFunc) *Spec {
+	result := new(Spec)
+
+	result.Name = expandVar(s.Name, lookup)
+	result.Tags = stringsExpanVar(s.Tags, lookup)
+	result.Froms = stringsExpanVar(s.Froms, lookup)
+	result.Srcs = stringsExpanVar(s.Srcs, lookup)
+	result.Dockerfile = expandVar(s.Dockerfile, lookup)
+	result.BuildArgs = stringsExpanVar(s.BuildArgs, lookup)
+
+	return result
+}

--- a/wanda/spec_test.go
+++ b/wanda/spec_test.go
@@ -31,3 +31,80 @@ func TestParseSpecFile(t *testing.T) {
 		t.Fatalf("got %+v, want %+v", loopback, spec)
 	}
 }
+
+func TestExpandVar(t *testing.T) {
+	envs := map[string]string{
+		"NAME":      "RAY",
+		"Name":      "Ray",
+		"name":      "ray",
+		"name0":     "ray0",
+		"NAME_NAME": "RAY_RAY",
+		"0":         "invalid env key, won't capture",
+		"0A":        "invalid env key, won't capture",
+	}
+
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{"$NAME", "RAY"},
+		{"My name is $Name", "My name is Ray"},
+		{"my name is $name!", "my name is ray!"},
+		{"my $$name0 is $name0~", "my $name0 is ray0~"},
+		{"", ""},
+		{"$", "$"},
+		{"$$", "$"},
+		{"$0", "$0"},
+		{"$0A", "$0A"},
+		{"$NAME-$NAME", "RAY-RAY"},
+		{"$NAME$NAME", "RAYRAY"},
+		{"$NAME_NAME", "RAY_RAY"},
+	} {
+		got := expandVar(test.in, func(k string) (string, bool) {
+			v, ok := envs[k]
+			return v, ok
+		})
+		if got != test.want {
+			t.Errorf("expandVar(%q) got %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
+func TestSpecExpand(t *testing.T) {
+	spec := &Spec{
+		Name:       "$NAME",
+		Froms:      []string{"ubuntu:$UBUNTU_VERSION"},
+		Dockerfile: "ci/docker/hello.Dockerfile",
+		Tags:       []string{"cr.ray.io/rayproject/hello"},
+		BuildArgs: []string{
+			"RAYCI_BUILDID=$$RAYCI_BUILDID",
+			"UBUNTU_VERSION=$UBUNTU_VERSION",
+		},
+	}
+
+	envs := map[string]string{
+		"NAME":           "hello",
+		"UBUNTU_VERSION": "22.04",
+		"RAYCI_BUILDID":  "abc123",
+	}
+
+	expanded := spec.expandVar(func(k string) (string, bool) {
+		v, ok := envs[k]
+		return v, ok
+	})
+
+	want := &Spec{
+		Name:       "hello",
+		Froms:      []string{"ubuntu:22.04"},
+		Dockerfile: "ci/docker/hello.Dockerfile",
+		Tags:       []string{"cr.ray.io/rayproject/hello"},
+		BuildArgs: []string{
+			"RAYCI_BUILDID=$RAYCI_BUILDID",
+			"UBUNTU_VERSION=22.04",
+		},
+	}
+
+	if !reflect.DeepEqual(expanded, want) {
+		t.Errorf("got %+v, want %+v", expanded, want)
+	}
+}


### PR DESCRIPTION
this allows using wanda spec file as a template, and enables to use it in a buildkite command step that has matrix.