### PR TITLE
[ci][fix] remove gpu_large pipeline from civ2 ci pipeline

### DIFF
--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -229,7 +229,8 @@ def main(
 
     pipeline_path = Path(pipeline).expanduser()
     if not pipeline_path.exists():
-        raise ValueError(f"Pipeline file does not exist: {pipeline}")
+        print(json.dumps([]))
+        return
 
     base_step_file = base_step_file or DEFAULT_BASE_STEPS_JSON
     with open(base_step_file, "r") as f:


### PR DESCRIPTION
pipeline.gpu_large is gone now, remove it form civ1 pipeline. 

Error: https://buildkite.com/ray-project/oss-ci-build-branch/builds/6610#018b5ece-49e4-45b9-8ed6-e1ca3554839a/3516-3538

I just print an empty group here so that the release branch still works with the existence of that pipeline.

