### PR TITLE
[rayci] add runner job skipping based on queue / instance type

### DIFF
--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -8,7 +8,9 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-const skipQueue = "~"
+const (
+	skipQueue = "~"
+)
 
 type dockerPluginConfig struct {
 	// AllowMountDockerSocket sets if it is allowed for jobs to mount the

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -8,6 +8,8 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+const skipQueue = "~"
+
 type dockerPluginConfig struct {
 	// AllowMountDockerSocket sets if it is allowed for jobs to mount the
 	// buildkite agent. This should only be set for pipelines where all builds
@@ -55,7 +57,8 @@ type config struct {
 
 	// RunnerQueues is a mapping from job instance types to buildkite agent
 	// queues for runners. If not set, the agent queue will be omitted, and the
-	// default queue will be used.
+	// default queue will be used. If it mapped to "~", then the job will be
+	// marked with `skip: true`.
 	//
 	// Optional but highly recommended.
 	RunnerQueues map[string]string `yaml:"runner_queues"`

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -8,9 +8,8 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-const (
-	skipQueue = "~"
-)
+// skipQueue is the queue name for skipping a buildkite runner job.
+const skipQueue = "~"
 
 type dockerPluginConfig struct {
 	// AllowMountDockerSocket sets if it is allowed for jobs to mount the

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -178,6 +178,9 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 	}
 
 	queue, _ := stringInMapAnyKey(step, "queue", "instance_type")
+	if queue == "" {
+		queue = "default"
+	}
 	agentQueue, err := c.mapAgent(queue)
 	if err != nil {
 		return nil, fmt.Errorf("map agent: %w", err)
@@ -185,7 +188,13 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 
 	result := cloneMapExcept(step, commandStepDropKeys)
 
-	result["agents"] = newBkAgents(agentQueue)
+	if agentQueue != "~" { // queue type not supported, skip.
+		result["agents"] = newBkAgents(agentQueue)
+	} else {
+		result["agents"] = newBkAgents("na")
+		result["skip"] = true
+	}
+
 	result["retry"] = defaultRayRetry
 	result["timeout_in_minutes"] = defaultTimeoutInMinutes
 	result["artifact_paths"] = defaultArtifactPaths

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -191,7 +191,6 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 	if agentQueue != skipQueue { // queue type not supported, skip.
 		result["agents"] = newBkAgents(agentQueue)
 	} else {
-		result["agents"] = newBkAgents("na")
 		result["skip"] = true
 	}
 

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -188,7 +188,7 @@ func (c *converter) convertPipelineStep(step map[string]any) (
 
 	result := cloneMapExcept(step, commandStepDropKeys)
 
-	if agentQueue != "~" { // queue type not supported, skip.
+	if agentQueue != skipQueue { // queue type not supported, skip.
 		result["agents"] = newBkAgents(agentQueue)
 	} else {
 		result["agents"] = newBkAgents("na")

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -123,7 +123,6 @@ func TestConvertPipelineStep(t *testing.T) {
 		},
 		out: map[string]any{
 			"commands":           []string{"echo 1"},
-			"agents":             newBkAgents("na"),
 			"timeout_in_minutes": defaultTimeoutInMinutes,
 			"artifact_paths":     defaultArtifactPaths,
 			"retry":              defaultRayRetry,

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -83,7 +83,7 @@ func TestConvertPipelineStep(t *testing.T) {
 
 		RunnerQueues: map[string]string{
 			"default": "fakerunner",
-			"broken":  "~",
+			"broken":  skipQueue,
 		},
 
 		Env: map[string]string{

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -81,7 +81,10 @@ func TestConvertPipelineStep(t *testing.T) {
 		CITemp:          "s3://ci-temp/",
 		CIWorkRepo:      "fakeecr",
 
-		RunnerQueues: map[string]string{"default": "fakerunner"},
+		RunnerQueues: map[string]string{
+			"default": "fakerunner",
+			"broken":  "~",
+		},
 
 		Env: map[string]string{
 			"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
@@ -112,6 +115,28 @@ func TestConvertPipelineStep(t *testing.T) {
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
+		},
+	}, {
+		in: map[string]any{
+			"commands":      []string{"echo 1"},
+			"instance_type": "broken",
+		},
+		out: map[string]any{
+			"commands":           []string{"echo 1"},
+			"agents":             newBkAgents("na"),
+			"timeout_in_minutes": defaultTimeoutInMinutes,
+			"artifact_paths":     defaultArtifactPaths,
+			"retry":              defaultRayRetry,
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":            buildID,
+				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
+				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
+				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_BRANCH":              "beta",
+
+				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
+			},
+			"skip": true,
 		},
 	}, {
 		in: map[string]any{


### PR DESCRIPTION
when an agent queue is mapped to `~`, will skip the runner job.