### PR TITLE
[ci] automatic retries for general errors

### DIFF
--- a/.buildkite/forge.rayci.yaml
+++ b/.buildkite/forge.rayci.yaml
@@ -12,6 +12,11 @@ steps:
     job_env: hello
     command: cat /opt/app/hello.txt
 
+  - name: retry test
+    depends_on: hello
+    job_env: hello
+    command: if [[ "$${BUILDKITE_RETRY_COUNT-0}" == 0 ]]; then exit 1; fi
+
   - name: python-base
     label: python {{matrix}}
     wanda: .buildkite/python.wanda.yaml

--- a/raycicmd/bk_pipeline.go
+++ b/raycicmd/bk_pipeline.go
@@ -39,6 +39,7 @@ var buildkiteEnvs = []string{
 	"BUILDKITE_COMMIT",
 	"BUILDKITE_HOOK_WORKING_DIR",
 	"BUILDKITE_LABEL",
+	"BUILDKITE_RETRY_COUNT",
 	"BUILDKITE_PIPELINE_ID",
 	"BUILDKITE_PIPELINE_SLUG",
 	"BUILDKITE_BUILD_ID",
@@ -114,6 +115,7 @@ var (
 	defaultRayRetry = map[string]any{
 		"manual": map[string]any{"permit_on_passed": true},
 		"automatic": []any{
+			map[string]any{"exit_status": 1, "limit": 1},
 			map[string]any{"exit_status": -1, "limit": 3},
 			map[string]any{"exit_status": 255, "limit": 3},
 		},


### PR DESCRIPTION
Enable automatic retries for general errors (wheel, docker, java, etc.). We changed test failure exit code to 42 in https://github.com/ray-project/ray/pull/41174 so this won't hide flaky tests.

Test:
- CI