### PR TITLE
[ci] fix windows docker

### DIFF
--- a/.buildkite/windows_docker.sh
+++ b/.buildkite/windows_docker.sh
@@ -3,6 +3,6 @@
 set -ex
 
 mkdir -p /c/tools
-wget -P /c/tools https://download.docker.com/win/static/stable/x86_64/docker-17.09.0-ce.zip
+curl https://download.docker.com/win/static/stable/x86_64/docker-17.09.0-ce.zip > /c/tools/docker-17.09.0-ce.zip
 unzip /c/tools/docker-17.09.0-ce.zip -d /c/tools
 rm /c/tools/docker-17.09.0-ce.zip


### PR DESCRIPTION
Use curl instead of wget to download docker binary

Test:
- CI