### PR TITLE
[ci] retry windows spot instances

### DIFF
--- a/raycicmd/bk_pipeline.go
+++ b/raycicmd/bk_pipeline.go
@@ -131,6 +131,7 @@ var (
 			map[string]any{"exit_status": 1, "limit": 1},
 			map[string]any{"exit_status": -1, "limit": 3},
 			map[string]any{"exit_status": 255, "limit": 3},
+			map[string]any{"exit_status": 3221225786, "limit": 3},
 		},
 	}
 	defaultBuilderRetry = map[string]any{


### PR DESCRIPTION
The exist code for dead windows spot instance is 3221225786 (https://buildkite.com/ray-project/postmerge/builds/2161#018c6968-6ee9-44c8-9cd2-3b41422f73b2) (as opposed to -1 or 255 in linux). Add it to the list for auto-retries.

Test:
- CI