### PR TITLE
[rayci] add artifact dir for windows

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+if [[ "$OSTYPE" == "msys" ]]; then
+  mkdir -p /c/tmp/artifacts
+else
+  mkdir -p /tmp/artifacts
+fi

--- a/.buildkite/windows.rayci.yaml
+++ b/.buildkite/windows.rayci.yaml
@@ -11,3 +11,11 @@ steps:
     commands: 
       - bash .buildkite/windows_docker.sh
       - docker run -i --rm $${RAYCI_WORK_REPO}:$${RAYCI_BUILD_ID}-hello-windows bash -c "echo 'Hello, Windows!'"
+
+  - name: ":windows: windows artifact mount"
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    depends_on: hello-windows
+    commands: 
+      - touch /c/artifact-mount/hello-windows.txt

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -258,11 +258,16 @@ func (c *converter) convertRunner(step map[string]any) (map[string]any, error) {
 	if dockerNetwork != "" {
 		dockerPluginConfig.network = dockerNetwork
 	}
+	v, _ := boolInMap(step, "mount_windows_artifacts")
+	dockerPluginConfig.mountWindowsArtifacts = v
 
 	if jobEnv == windowsJobEnv { // a special job env for windows
 		result["plugins"] = []any{map[string]any{
 			dockerPlugin: makeRayWindowsDockerPlugin(dockerPluginConfig),
 		}}
+		if dockerPluginConfig.mountWindowsArtifacts {
+			result["artifact_paths"] = windowsArtifactPaths
+		}
 	} else if jobEnv == macosJobEnv { // a special job env for macos
 		result["plugins"] = []any{map[string]any{
 			macosSandboxPlugin: map[string]string{

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -249,6 +249,34 @@ func TestConvertPipelineStep(t *testing.T) {
 		},
 	}, {
 		in: map[string]any{
+			"label":                   "windows job",
+			"key":                     "win",
+			"command":                 "echo windows",
+			"job_env":                 "WINDOWS",
+			"instance_type":           "windows",
+			"mount_windows_artifacts": true,
+		},
+		out: map[string]any{
+			"label":   "windows job",
+			"key":     "win",
+			"command": "echo windows",
+			"agents":  newBkAgents("fakewinrunner"),
+
+			"artifact_paths":     windowsArtifactPaths,
+			"timeout_in_minutes": defaultTimeoutInMinutes,
+			"retry":              defaultRayRetry,
+			"env": map[string]string{
+				"RAYCI_BUILD_ID":            buildID,
+				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
+				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
+				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_BRANCH":              "beta",
+
+				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
+			},
+		},
+	}, {
+		in: map[string]any{
 			"label":         "windows job",
 			"key":           "win",
 			"command":       "echo windows",

--- a/raycicmd/rayci_pipeline.go
+++ b/raycicmd/rayci_pipeline.go
@@ -27,12 +27,12 @@ var (
 		"label", "name", "key", "depends_on", "soft_fail", "matrix",
 		"instance_type", "queue", "job_env", "tags",
 		"docker_publish_tcp_ports", "docker_network",
-		"mount_buildkite_agent",
+		"mount_buildkite_agent", "mount_windows_artifacts",
 	}
 	commandStepDropKeys = []string{
 		"instance_type", "queue", "job_env", "tags",
 		"docker_publish_tcp_ports", "docker_network",
-		"mount_buildkite_agent",
+		"mount_buildkite_agent", "mount_windows_artifacts",
 	}
 
 	wandaStepAllowedKeys = []string{


### PR DESCRIPTION
Add artifact dir for windows. Create a new windows jobenv that mounts artifact dir, this is for safe roll out of this feature (the new jobenv requires the existent of the artifact dir that needs to set up in pre-commit).

Test:
- CI