### PR TITLE
[ci] fix base again

### DIFF
--- a/ray_ci/build_base_build.sh
+++ b/ray_ci/build_base_build.sh
@@ -61,7 +61,7 @@ fi
 echo "--- :docker: Building base dependency image for ML :airplane:"
 
 if [[ -f ci/docker/base.ml.py39.wanda.yaml ]]; then
-  "${WANDA[@]}" ci/docker/base.ml.wanda.yaml
+  "${WANDA[@]}" ci/docker/base.ml.py39.wanda.yaml
 else
   docker build --progress=plain \
     --build-arg REMOTE_CACHE_URL \


### PR DESCRIPTION
Forgot to update the ml base. Previous PR run test the wrong way too so didn't catch this.

Test: https://buildkite.com/ray-project/oss-ci-base-image-builder/builds/553 (set PIPELINE_REPO_BRANCH="can-fix-base-02")

