### PR TITLE
[rayci] allow running unit tests on osx

### DIFF
--- a/wanda/docker_cmd_test.go
+++ b/wanda/docker_cmd_test.go
@@ -3,6 +3,7 @@ package wanda
 import (
 	"testing"
 
+	"runtime"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -10,6 +11,11 @@ import (
 )
 
 func TestDockerCmdBuild(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux")
+		return
+	}
+
 	cmd := newDockerCmd(&dockerCmdConfig{}) // uses real docker client
 
 	ts := newTarStream()
@@ -69,6 +75,11 @@ func TestDockerCmdBuild(t *testing.T) {
 }
 
 func TestDockerCmdBuild_copyEverything(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux")
+		return
+	}
+
 	cmd := newDockerCmd(&dockerCmdConfig{}) // uses real docker client
 
 	cmd.setWorkDir("testdata")

--- a/wanda/docker_cmd_test.go
+++ b/wanda/docker_cmd_test.go
@@ -3,7 +3,6 @@ package wanda
 import (
 	"testing"
 
-	"runtime"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -11,11 +10,6 @@ import (
 )
 
 func TestDockerCmdBuild(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux")
-		return
-	}
-
 	cmd := newDockerCmd(&dockerCmdConfig{}) // uses real docker client
 
 	ts := newTarStream()
@@ -75,11 +69,6 @@ func TestDockerCmdBuild(t *testing.T) {
 }
 
 func TestDockerCmdBuild_copyEverything(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux")
-		return
-	}
-
 	cmd := newDockerCmd(&dockerCmdConfig{}) // uses real docker client
 
 	cmd.setWorkDir("testdata")

--- a/wanda/forge_test.go
+++ b/wanda/forge_test.go
@@ -2,6 +2,7 @@ package wanda
 
 import (
 	"net"
+	"runtime"
 	"testing"
 
 	"archive/tar"
@@ -202,9 +203,8 @@ func TestForge(t *testing.T) {
 }
 
 func TestForgeWithWorkRepo(t *testing.T) {
-	if os.Getenv("BUILDKITE") == "true" {
-		t.Log("does not work when the daemon cannot reach the local registry")
-		t.Skip()
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux")
 		return
 	}
 

--- a/wanda/forge_test.go
+++ b/wanda/forge_test.go
@@ -1,15 +1,15 @@
 package wanda
 
 import (
-	"net"
-	"runtime"
 	"testing"
 
 	"archive/tar"
 	"fmt"
 	"io"
+	"net"
 	"net/http/httptest"
 	"os"
+	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"


### PR DESCRIPTION
and skipping the test that runs only on Linux

also runs the `TestForgeWithWorkRepo` test on buildkite.