### PR TITLE
Pin dind version for KubeRay CI

### DIFF
--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -12,7 +12,7 @@
 		]
 	},
 	"plugins": [{
-			"ray-project/dind#104e9f556a0144ddd7f6e7f6d92346dcbb75fa79": {
+			"ray-project/dind#v1.0.11": {
 				"network-name": "dind-network",
 				"certs-volume-name": "ray-docker-certs-client",
 				"additional-volume-mount": "shared-ci-volume:/shared"

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -12,7 +12,7 @@
 		]
 	},
 	"plugins": [{
-			"ray-project/dind#architkulkarni-patch-1": {
+			"ray-project/dind#104e9f556a0144ddd7f6e7f6d92346dcbb75fa79": {
 				"network-name": "dind-network",
 				"certs-volume-name": "ray-docker-certs-client",
 				"additional-volume-mount": "shared-ci-volume:/shared"

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -12,7 +12,7 @@
 		]
 	},
 	"plugins": [{
-			"ray-project/dind#v1.0.10": {
+			"ray-project/dind#architkulkarni-patch-1": {
 				"network-name": "dind-network",
 				"certs-volume-name": "ray-docker-certs-client",
 				"additional-volume-mount": "shared-ci-volume:/shared"


### PR DESCRIPTION
Not sure if it is possible to trigger KubeRay CI against this PR before merging, but if it's possible, that would be ideal.

This PR updates the version of the dind plugin in order to get the changes from https://github.com/ray-project/dind-buildkite-plugin/pull/1 which pins the `dind` version to fix KubeRay CI.

Reference for the pinning syntax: https://buildkite.com/docs/plugins/using#pinning-plugin-versions

Closes https://github.com/ray-project/kuberay/issues/1859