### PR TITLE
[ci] fix window shell error

### DIFF
--- a/raycicmd/bk_pipeline.go
+++ b/raycicmd/bk_pipeline.go
@@ -86,7 +86,7 @@ func makeRayWindowsDockerPlugin(config *stepDockerPluginConfig) map[string]any {
 
 	m := map[string]any{
 		"image":          windowsBuildEnvImage,
-		"shell":          []string{"bash", "-c"},
+		"shell":          []string{"bash", "-eo", "pipefail", "-c"},
 		"shm-size":       "2.5gb",
 		"mount-checkout": true,
 		"environment":    envs,


### PR DESCRIPTION
Windows CI jobs might swallow errors when the errors happen in the middle of the command list. This PR runs bash with both -e and -o pipefail options to fix that.

Test:
- CI, check that it fails here https://buildkite.com/ray-project/rayci/builds/736#018d53fc-ec69-4555-898b-6d45ca121f5f