### PR TITLE
change test name from TestToStringList

### DIFF
--- a/raycicmd/util_test.go
+++ b/raycicmd/util_test.go
@@ -228,7 +228,7 @@ func TestCheckStepKeys(t *testing.T) {
 	}
 }
 
-func TestFieldToStringList(t *testing.T) {
+func TestToStringList(t *testing.T) {
 	for _, test := range []struct {
 		in   any
 		want []string


### PR DESCRIPTION
the function under test has name of `toStringList`