### PR TITLE
[rayci] add block/wait step check

### DIFF
--- a/raycicmd/step_converter.go
+++ b/raycicmd/step_converter.go
@@ -19,9 +19,13 @@ type basicStepConverter struct {
 	dropKeys    []string
 }
 
-func (c *basicStepConverter) match(step map[string]any) bool {
-	_, ok := step[c.signatureKey]
+func stepHasKey(step map[string]any, k string) bool {
+	_, ok := step[k]
 	return ok
+}
+
+func (c *basicStepConverter) match(step map[string]any) bool {
+	return stepHasKey(step, c.signatureKey)
 }
 
 func (c *basicStepConverter) convert(step map[string]any) (
@@ -43,4 +47,8 @@ var blockConverter = &basicStepConverter{
 	signatureKey: "block",
 	allowedKeys:  blockStepAllowedKeys,
 	dropKeys:     blockStepDropKeys,
+}
+
+func isBlockOrWait(step map[string]any) bool {
+	return stepHasKey(step, "wait") || stepHasKey(step, "block")
 }

--- a/raycicmd/step_converter_test.go
+++ b/raycicmd/step_converter_test.go
@@ -1,0 +1,108 @@
+package raycicmd
+
+import (
+	"testing"
+
+	"reflect"
+)
+
+func TestWaitConverter(t *testing.T) {
+	for _, test := range []struct {
+		step map[string]any
+		want map[string]any
+	}{{
+		step: map[string]any{"wait": nil},
+		want: map[string]any{"wait": nil},
+	}, {
+		step: map[string]any{"wait": "true", "depends_on": "a"},
+		want: map[string]any{"wait": "true", "depends_on": "a"},
+	}, {
+		step: map[string]any{
+			"wait": "true", "if": "true", "depends_on": []string{"dep"},
+			"continue_on_failure": "true",
+			"tags":                []string{"tag"},
+		},
+		want: map[string]any{
+			"wait": "true", "if": "true", "depends_on": []string{"dep"},
+			"continue_on_failure": "true",
+		},
+	}} {
+		match := waitConverter.match(test.step)
+		if !match {
+			t.Errorf("cannot match wait step %+v", test.step)
+		}
+
+		got, err := waitConverter.convert(test.step)
+		if err != nil {
+			t.Errorf("convert %+v got error %v", test.step, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf(
+				"convert %+v, got %+v, want %+v",
+				test.step, got, test.want,
+			)
+		}
+	}
+}
+
+func TestBlockConverter(t *testing.T) {
+	for _, test := range []struct {
+		step map[string]any
+		want map[string]any
+	}{{
+		step: map[string]any{"block": "click me"},
+		want: map[string]any{"block": "click me"},
+	}, {
+		step: map[string]any{"block": "true", "depends_on": "a"},
+		want: map[string]any{"block": "true", "depends_on": "a"},
+	}, {
+		step: map[string]any{
+			"block": "me", "if": "false", "depends_on": []string{"dep"},
+			"tags": []string{"tag"},
+		},
+		want: map[string]any{
+			"block": "me", "if": "false", "depends_on": []string{"dep"},
+		},
+	}} {
+		match := blockConverter.match(test.step)
+		if !match {
+			t.Errorf("cannot match wait step %+v", test.step)
+		}
+
+		got, err := blockConverter.convert(test.step)
+		if err != nil {
+			t.Errorf("convert %+v got error %v", test.step, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf(
+				"convert %+v, got %+v, want %+v",
+				test.step, got, test.want,
+			)
+		}
+	}
+}
+
+func TestIsBlockOrWait(t *testing.T) {
+	for _, test := range []map[string]any{
+		{"wait": "true"},
+		{"block": "true"},
+		{"block": "me", "if": "false", "depends_on": []string{"dep"}},
+		{"wait": nil, "tags": []string{"tag"}},
+	} {
+		if !isBlockOrWait(test) {
+			t.Errorf("%+v should be treated as a block or wait step", test)
+		}
+	}
+
+	for _, test := range []map[string]any{
+		{},
+		{"command": "echo hello"},
+		{"commands": []string{"echo hello"}},
+	} {
+		if isBlockOrWait(test) {
+			t.Errorf("%+v should not be treated as a block or wait step", test)
+		}
+	}
+}


### PR DESCRIPTION
block/wait steps need to be treated in special ways in dependency tracking, so add a utility function for it.

also adds more unit tests for basic step converter for block and wait steps.