### PR TITLE
[rayci] add dependency tracking ability in stepNode

### DIFF
--- a/raycicmd/step_node.go
+++ b/raycicmd/step_node.go
@@ -51,7 +51,9 @@ func setToStringList(set map[string]struct{}) []string {
 	return list
 }
 
-func (n *stepNode) deps() []string { return setToStringList(n.depSet) }
+func (n *stepNode) deps() []string {
+	return setToStringList(n.depSet)
+}
 
 func (n *stepNode) reverseDeps() []string {
 	return setToStringList(n.reverseDepSet)

--- a/raycicmd/step_node.go
+++ b/raycicmd/step_node.go
@@ -1,5 +1,9 @@
 package raycicmd
 
+import (
+	"sort"
+)
+
 // stepNode is a node for a generic step. The step can be a group, a wait,
 // a block or a command step.
 type stepNode struct {
@@ -17,6 +21,38 @@ type stepNode struct {
 	// Fields used for steps.
 	src map[string]any // Source definition of the step when it is not a group.
 
+	depSet        map[string]struct{}
+	reverseDepSet map[string]struct{}
+
 	// Marked is set to true when the node will be included in a conversion.
 	marked bool
+}
+
+func (n *stepNode) addDep(id string) {
+	if n.depSet == nil {
+		n.depSet = make(map[string]struct{})
+	}
+	n.depSet[id] = struct{}{}
+}
+
+func (n *stepNode) addReverseDep(id string) {
+	if n.reverseDepSet == nil {
+		n.reverseDepSet = make(map[string]struct{})
+	}
+	n.reverseDepSet[id] = struct{}{}
+}
+
+func setToStringList(set map[string]struct{}) []string {
+	var list []string
+	for k := range set {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return list
+}
+
+func (n *stepNode) deps() []string { return setToStringList(n.depSet) }
+
+func (n *stepNode) reverseDeps() []string {
+	return setToStringList(n.reverseDepSet)
 }

--- a/raycicmd/step_node_test.go
+++ b/raycicmd/step_node_test.go
@@ -6,56 +6,6 @@ import (
 	"reflect"
 )
 
-func TestStepNodeDeps(t *testing.T) {
-	n := &stepNode{id: "mine"}
-
-	if got := n.deps(); len(got) != 0 {
-		t.Errorf("got deps %v, want empty list", n.deps())
-	}
-
-	n.addDep("foo")
-	want := []string{"foo"}
-	if got := n.deps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	n.addDep("bar")
-	want = []string{"bar", "foo"}
-	if got := n.deps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	n.addDep("foo")
-	if got := n.deps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-}
-
-func TestStepNodeReverseDeps(t *testing.T) {
-	n := &stepNode{id: "mine"}
-
-	if got := n.reverseDeps(); len(got) != 0 {
-		t.Errorf("got deps %v, want empty list", n.deps())
-	}
-
-	n.addReverseDep("foo")
-	want := []string{"foo"}
-	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	n.addReverseDep("bar")
-	want = []string{"bar", "foo"}
-	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	n.addReverseDep("foo")
-	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-}
-
 func TestIntersects(t *testing.T) {
 	for _, test := range []struct {
 		set1 []string
@@ -142,5 +92,55 @@ func TestStepNodeHasTagIn(t *testing.T) {
 				got, test.want,
 			)
 		}
+	}
+}
+
+func TestStepNodeDeps(t *testing.T) {
+	n := &stepNode{id: "mine"}
+
+	if got := n.deps(); len(got) != 0 {
+		t.Errorf("got deps %v, want empty list", n.deps())
+	}
+
+	n.addDep("foo")
+	want := []string{"foo"}
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addDep("bar")
+	want = []string{"bar", "foo"}
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addDep("foo")
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestStepNodeReverseDeps(t *testing.T) {
+	n := &stepNode{id: "mine"}
+
+	if got := n.reverseDeps(); len(got) != 0 {
+		t.Errorf("got deps %v, want empty list", n.deps())
+	}
+
+	n.addReverseDep("foo")
+	want := []string{"foo"}
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addReverseDep("bar")
+	want = []string{"bar", "foo"}
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addReverseDep("foo")
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/raycicmd/step_node_test.go
+++ b/raycicmd/step_node_test.go
@@ -1,8 +1,9 @@
 package raycicmd
 
 import (
-	"reflect"
 	"testing"
+
+	"reflect"
 )
 
 func TestStepNodeDeps(t *testing.T) {

--- a/raycicmd/step_node_test.go
+++ b/raycicmd/step_node_test.go
@@ -1,0 +1,56 @@
+package raycicmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStepNodeDeps(t *testing.T) {
+	n := &stepNode{id: "mine"}
+
+	if got := n.deps(); len(got) != 0 {
+		t.Errorf("got deps %v, want empty list", n.deps())
+	}
+
+	n.addDep("foo")
+	want := []string{"foo"}
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addDep("bar")
+	want = []string{"bar", "foo"}
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addDep("foo")
+	if got := n.deps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestStepNodeReverseDeps(t *testing.T) {
+	n := &stepNode{id: "mine"}
+
+	if got := n.reverseDeps(); len(got) != 0 {
+		t.Errorf("got deps %v, want empty list", n.deps())
+	}
+
+	n.addReverseDep("foo")
+	want := []string{"foo"}
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addReverseDep("bar")
+	want = []string{"bar", "foo"}
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	n.addReverseDep("foo")
+	if got := n.reverseDeps(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
can add dependencies and reverse dependencies, and maintain as a set.

the dependencies are for including: when a step is included, its dependencies also need to be included.

and the reverse dependencies are for rejecting: when a step is rejected/disabled, its reverse dependencies (dependents) also need to be rejected.