### PR TITLE
[rayci] split hit into accept and reject

### DIFF
--- a/raycicmd/make.go
+++ b/raycicmd/make.go
@@ -90,16 +90,15 @@ func makePipeline(repoDir string, config *config, info *buildInfo) (
 
 	c := newConverter(config, info)
 
-	// Build steps for CI.
+	filter, err := newTagsStepFilter(config.SkipTags, config.TagFilterCommand)
+	if err != nil {
+		return nil, fmt.Errorf("run tag filter command: %w", err)
+	}
 
+	// Build steps for CI.
 	bkDirs := config.BuildkiteDirs
 	if len(bkDirs) == 0 {
 		bkDirs = []string{".buildkite"}
-	}
-
-	tagFilters, err := newStepFilter(config.SkipTags, config.TagFilterCommand)
-	if err != nil {
-		return nil, fmt.Errorf("run tag filter command: %w", err)
 	}
 
 	var groups []*pipelineGroup
@@ -121,11 +120,10 @@ func makePipeline(repoDir string, config *config, info *buildInfo) (
 			groups = append(groups, g)
 		}
 	}
-
 	sortPipelineGroups(groups)
 
 	// map each file into a group.
-	steps, err := c.convertGroups(groups, tagFilters)
+	steps, err := c.convertGroups(groups, filter)
 	if err != nil {
 		return nil, fmt.Errorf("convert pipeline groups: %w", err)
 	}

--- a/raycicmd/step_filter_test.go
+++ b/raycicmd/step_filter_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func TestNewStepFilter(t *testing.T) {
+func TestNewTagsStepFilter(t *testing.T) {
 	for _, test := range []struct {
 		cmd      []string
 		skipTags []string
@@ -40,7 +40,7 @@ func TestNewStepFilter(t *testing.T) {
 		cmd:  []string{"./local-not-exist.sh"},
 		want: &stepFilter{runAll: true},
 	}} {
-		got, err := newStepFilter(test.skipTags, test.cmd)
+		got, err := newTagsStepFilter(test.skipTags, test.cmd)
 		if test.wantErr {
 			if err == nil {
 				t.Errorf("run %q: want error, got nil", test.cmd)
@@ -60,7 +60,7 @@ func TestNewStepFilter(t *testing.T) {
 	}
 }
 
-func TestStepFilter(t *testing.T) {
+func TestStepFilter_tags(t *testing.T) {
 	filter := &stepFilter{
 		skipTags: []string{"disabled"},
 		tags:     []string{"tune"},

--- a/raycicmd/step_filter_test.go
+++ b/raycicmd/step_filter_test.go
@@ -89,6 +89,35 @@ func TestStepFilter_tags(t *testing.T) {
 	}
 }
 
+func TestStepFilter_tagsReject(t *testing.T) {
+	filter := &stepFilter{
+		skipTags: []string{"disabled"},
+		tags:     []string{"tune"},
+	}
+
+	for _, tags := range [][]string{
+		{},
+		{"tune"},
+		{"tune", "foo"},
+		{"bar", "tune"},
+		{"data"},
+	} {
+		if filter.reject(&stepNode{tags: tags}) {
+			t.Errorf("rejects %+v", tags)
+		}
+	}
+
+	for _, tags := range [][]string{
+		{"disabled"},
+		{"tune", "disabled"},
+		{"disabled", "tune"},
+	} {
+		if !filter.reject(&stepNode{tags: tags}) {
+			t.Errorf("does not reject %+v", tags)
+		}
+	}
+}
+
 func TestStepFilter_runAll(t *testing.T) {
 	filter := &stepFilter{
 		skipTags: []string{"disabled"},


### PR DESCRIPTION
this is required because rejecting a group means rejecting all
steps in the group, where accepting only mean include the group
even when there are no steps in the group.
