### PR TITLE
[rayci] add a total steps method for bk pipelines

### DIFF
--- a/raycicmd/bk_pipeline.go
+++ b/raycicmd/bk_pipeline.go
@@ -16,6 +16,14 @@ type bkPipeline struct {
 	Steps []*bkPipelineGroup `yaml:"steps,omitempty"`
 }
 
+func (p *bkPipeline) totalSteps() int {
+	total := 0
+	for _, group := range p.Steps {
+		total += len(group.Steps)
+	}
+	return total
+}
+
 func newBkAgents(queue string) map[string]any {
 	return map[string]any{"queue": queue}
 }

--- a/raycicmd/bk_pipeline_test.go
+++ b/raycicmd/bk_pipeline_test.go
@@ -1,0 +1,28 @@
+package raycicmd
+
+import (
+	"testing"
+)
+
+func TestBkPipelineTotalSteps(t *testing.T) {
+	p := &bkPipeline{
+		Steps: []*bkPipelineGroup{
+			{
+				Group: "group1",
+				Steps: []any{
+					map[string]any{"command": "echo step1"},
+					map[string]any{"command": "echo step2"},
+				},
+			},
+			{
+				Group: "group2",
+				Steps: []any{
+					map[string]any{"command": "echo step3"},
+				},
+			},
+		},
+	}
+	if total := p.totalSteps(); total != 3 {
+		t.Errorf("totalSteps() = %d; want 3", total)
+	}
+}

--- a/raycicmd/make.go
+++ b/raycicmd/make.go
@@ -129,11 +129,7 @@ func makePipeline(repoDir string, config *config, info *buildInfo) (
 	}
 	pl.Steps = steps
 
-	totalSteps := 0
-	for _, group := range pl.Steps {
-		totalSteps += len(group.Steps)
-	}
-	if totalSteps == 0 {
+	if pl.totalSteps() == 0 {
 		q, ok := config.RunnerQueues["default"]
 		if !ok {
 			q = ""


### PR DESCRIPTION
some small refactoring to make `make.go` a bit easier to read.