### PR TITLE
[rayci] adding RAYCI_SCHEDULE env var to pass through postmerge ci jobs

### DIFF
--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -103,6 +103,9 @@ func (c *commandConverter) convert(step map[string]any) (
 	for _, k := range c.config.HookEnvKeys {
 		envKeys[k] = struct{}{}
 	}
+	for _, k := range c.config.BuildEnvKeys {
+		envKeys[k] = struct{}{}
+	}
 	var envKeyList []string
 	for k := range envKeys {
 		envKeyList = append(envKeyList, k)
@@ -110,9 +113,7 @@ func (c *commandConverter) convert(step map[string]any) (
 	sort.Strings(envKeyList)
 
 	jobEnv, _ := stringInMap(step, "job_env")
-	dockerPluginConfig := &stepDockerPluginConfig{
-		extraEnvs: envKeyList,
-	}
+	dockerPluginConfig := &stepDockerPluginConfig{extraEnvs: envKeyList}
 	if d := c.config.DockerPlugin; d != nil && d.AllowMountBuildkiteAgent {
 		v, _ := boolInMap(step, "mount_buildkite_agent")
 		dockerPluginConfig.mountBuildkiteAgent = v

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -84,6 +84,12 @@ type config struct {
 	// Optional.
 	Env map[string]string `yaml:"env"`
 
+	// BuildEnvKeys is a list of environment variable keys to pass into
+	// build jobs from the buildkite build.
+	//
+	// Optional.
+	BuildEnvKeys []string `yaml:"build_env_keys"`
+
 	// HookEnvKeys is the list of environment variable keys to pass into
 	// build jobs from buildkite hooks.
 	//
@@ -194,7 +200,8 @@ var branchPipelineConfig = &config{
 		"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
 	},
 
-	HookEnvKeys: []string{"RAYCI_CHECKOUT_DIR"},
+	BuildEnvKeys: []string{"RAYCI_SCHEDULE"},
+	HookEnvKeys:  []string{"RAYCI_CHECKOUT_DIR"},
 
 	SkipTags: []string{"disabled"},
 }

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -104,7 +104,8 @@ func TestConvertPipelineStep(t *testing.T) {
 			"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 		},
 
-		HookEnvKeys: []string{"RAYCI_CHECKOUT_DIR"},
+		BuildEnvKeys: []string{"RAYCI_SCHEDULE"},
+		HookEnvKeys:  []string{"RAYCI_CHECKOUT_DIR"},
 	}, info)
 
 	const artifactDest = "s3://artifacts_bucket/abcdefg1234567890"
@@ -436,6 +437,7 @@ func TestConvertPipelineStep(t *testing.T) {
 			"RAYCI_TEMP",
 			"RAYCI_WORK_REPO",
 			"BUILDKITE_BAZEL_CACHE_URL",
+			"RAYCI_SCHEDULE",
 			"RAYCI_CHECKOUT_DIR",
 		} {
 			if !findInSlice(envs, env) {


### PR DESCRIPTION
so that we can adjust behavior of the CI pipeline on scheduled builds.