### PR TITLE
[rayci] Add key in trigger step allowed key list

### DIFF
--- a/raycicmd/rayci_pipeline.go
+++ b/raycicmd/rayci_pipeline.go
@@ -36,6 +36,7 @@ var (
 	triggerStepAllowedKeys = []string{
 		"trigger", "label", "async", "build", "depends_on",
 		"tags", "if", "soft_fail", "allow_dependency_failure",
+		"key",
 	}
 	triggerStepDropKeys = []string{"tags"}
 

--- a/raycicmd/step_converter_test.go
+++ b/raycicmd/step_converter_test.go
@@ -105,6 +105,7 @@ func TestTriggerConverter(t *testing.T) {
 	}, {
 		step: map[string]any{
 			"trigger":                  "me",
+			"key":                      "my_key",
 			"depends_on":               "a",
 			"if":                       1 < 2,
 			"soft_fail":                "true",
@@ -113,6 +114,7 @@ func TestTriggerConverter(t *testing.T) {
 		},
 		want: map[string]any{
 			"trigger":                  "me",
+			"key":                      "my_key",
 			"depends_on":               "a",
 			"if":                       1 < 2,
 			"soft_fail":                "true",


### PR DESCRIPTION
Apparently Buildkite does support `key` attribute for every step even though they are not listed in the documentation: https://forum.buildkite.community/t/step-key-for-trigger-steps/1208

Adding `key` here so we can use it for dependency chain in release automation pipeline
