### PR TITLE
[ci] add retries for java tests

### DIFF
--- a/raycicmd/bk_pipeline.go
+++ b/raycicmd/bk_pipeline.go
@@ -160,6 +160,7 @@ var (
 		"automatic": makeAutomaticRetryConfig([]int{
 			-1,
 			255,
+			3,          // java test failures
 			53,         // elastic CI stack environment hook failure
 			125,        // container failed
 			126,        // windows wheel build errors


### PR DESCRIPTION
Add more automated retries for transient error code. This time it's java. Example: https://buildkite.com/ray-project/premerge/builds/21717#018e343b-c8b3-4867-bf23-adaa6bfe3eac