### PR TITLE
[rayci] build release binaries for all supported platforms

### DIFF
--- a/.buildkite/release.rayci.yaml
+++ b/.buildkite/release.rayci.yaml
@@ -7,5 +7,5 @@ steps:
     instance_type: release
     commands:
       - bash release.sh
-      - cp _/release/* /artifact-mount
+      - cp _release/* /artifact-mount
     depends_on: forge

--- a/.buildkite/release.rayci.yaml
+++ b/.buildkite/release.rayci.yaml
@@ -1,7 +1,11 @@
 group: release
 steps:
-  - name: hello-release
+  # Use release queue to build rayci and wanda release binaries.
+  # This makes sure that the release queue is working and also
+  # builds the releases and save the binaries in build artifacts.
+  - name: rayci and wanda binaries
     instance_type: release
     commands:
-      - echo "Hello, Release!"
+      - bash release.sh
+      - cp _/release/* /artifact-mount
     depends_on: forge

--- a/release.sh
+++ b/release.sh
@@ -5,14 +5,22 @@ set -euxo pipefail
 mkdir -p _release
 rm -f _release/*
 
-function build {
+function build_rayci {
 	RAYCI_OS="$1"
 	RAYCI_ARCH="$2"
 
 	GOOS="$RAYCI_OS" GOARCH="$RAYCI_ARCH" go build -trimpath -o "_release/rayci-${RAYCI_OS}-${RAYCI_ARCH}" .
+}
+
+function build_wanda {
+	RAYCI_OS="$1"
+	RAYCI_ARCH="$2"
+
 	GOOS="$RAYCI_OS" GOARCH="$RAYCI_ARCH" go build -trimpath -o "_release/wanda-${RAYCI_OS}-${RAYCI_ARCH}" ./wanda/wanda
 }
 
-build linux amd64
-build linux arm64
-build windows amd64
+build_rayci linux amd64
+
+build_wanda linux amd64
+build_wanda linux arm64
+build_wanda windows amd64

--- a/release.sh
+++ b/release.sh
@@ -5,8 +5,14 @@ set -euxo pipefail
 mkdir -p _release
 rm -f _release/*
 
-RAYCI_OS="$(go env GOOS)"
-RAYCI_ARCH="$(go env GOARCH)"
+function build {
+	RAYCI_OS="$1"
+	RAYCI_ARCH="$2"
 
-go build -trimpath -o "_release/rayci-${RAYCI_OS}-${RAYCI_ARCH}" .
-go build -trimpath -o "_release/wanda-${RAYCI_OS}-${RAYCI_ARCH}" ./wanda/wanda
+	GOOS="$RAYCI_OS" GOARCH="$RAYCI_ARCH" go build -trimpath -o "_release/rayci-${RAYCI_OS}-${RAYCI_ARCH}" .
+	GOOS="$RAYCI_OS" GOARCH="$RAYCI_ARCH" go build -trimpath -o "_release/wanda-${RAYCI_OS}-${RAYCI_ARCH}" ./wanda/wanda
+}
+
+build linux amd64
+build linux arm64
+build windows amd64


### PR DESCRIPTION
`rayci` only supports linux amd64, `wanda` supports linux amd64, arm64 and windows amd64.