### PR TITLE
[rayci] bootstrap: download and use released binary

### DIFF
--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -2,9 +2,21 @@
 
 set -euo pipefail
 
-RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
-
 TMP_DIR="$(mktemp -d)"
+
+if [[ -f .rayciversion ]]; then
+  RAYCI_VERSION="$(cat .rayciversion)"
+  echo "--- Install rayci binary ${RAYCI_VERSION}"
+  curl -sfL "https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/rayci-linux-amd64" -o "$TMP_DIR/rayci"
+  chmod +x "$TMP_DIR/rayci"
+  exec "$TMP_DIR/rayci" "$@"
+
+  exit 1  # Unreachable; just for safe-guarding.
+fi
+
+# Legacy path; build from source.
+
+RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
 
 echo "--- Install rayci"
 

--- a/run_wanda.sh
+++ b/run_wanda.sh
@@ -2,15 +2,42 @@
 
 set -euo pipefail
 
-RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
-
 TMP_DIR="$(mktemp -d)"
+
+if [[ -f .rayciversion ]]; then
+  RAYCI_VERSION="$(cat .rayciversion)"
+  echo "--- Install wanda binary ${RAYCI_VERSION}"
+
+  WANDA_URL_PREFIX="https://github.com/ray-project/rayci/releases/download/"
+  if [[ "$OSTYPE" =~ ^linux ]]; then
+    if [[ "$HOSTTYPE" == "arm64" || "$HOSTTYPE" == "aarch64" ]]; then
+      WANDA_URL="${WANDA_URL_PREFIX}v${RAYCI_VERSION}/wanda-linux-arm64"
+    else
+      WANDA_URL="${WANDA_URL_PREFIX}v${RAYCI_VERSION}/wanda-linux-amd64"
+    fi
+  elif [[ "$OSTYPE" == msys ]]; then
+    WANDA_URL="${WANDA_URL_PREFIX}v${RAYCI_VERSION}/wanda-windows-amd64"
+  else
+    echo "Unsupported platform for wanda binary: ${OSTYPE} ${HOSTTYPE}"
+    exit 1
+  fi
+
+  curl -sfL "${WANDA_URL}" -o "$TMP_DIR/wanda"
+  chmod +x "$TMP_DIR/wanda"
+  exec "$TMP_DIR/wanda" "$@"
+
+  exit 1  # Unreachable; just for safe-guarding.
+fi
+
+# Legacy path; build from source.
+
+RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
 
 echo "--- Install wanda ($HOSTTYPE)"
 
 readonly GO_VERSION=1.22.2
 
-if [[ "${OSTYPE}" == msys ]]; then
+if [[ "$OSTYPE" == msys ]]; then
   curl -sfL "https://go.dev/dl/go${GO_VERSION}.windows-amd64.zip" > "$TMP_DIR/go.zip"
   unzip "$TMP_DIR/go.zip" -d "$TMP_DIR"
   rm "$TMP_DIR/go.zip"


### PR DESCRIPTION
saves about 40s of bootstrap time on critical path, and maybe same amount of time on every builder job.