### PR TITLE
[rayci] send in rayci's step id as env var

### DIFF
--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -95,7 +95,7 @@ func (c *commandConverter) convert(id string, step map[string]any) (
 
 	envMap := copyEnvMap(c.envMap)
 	if id != "" {
-		envMap["RAYCI_JOB_ID"] = id
+		envMap["RAYCI_STEP_ID"] = id
 	}
 	result["env"] = envMap
 

--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -58,7 +58,7 @@ func (c *commandConverter) match(step map[string]any) bool {
 	return true
 }
 
-func (c *commandConverter) convert(step map[string]any) (
+func (c *commandConverter) convert(id string, step map[string]any) (
 	map[string]any, error,
 ) {
 	if err := checkStepKeys(step, commandStepAllowedKeys); err != nil {
@@ -94,6 +94,9 @@ func (c *commandConverter) convert(step map[string]any) (
 	}
 
 	envMap := copyEnvMap(c.envMap)
+	if id != "" {
+		envMap["RAYCI_JOB_ID"] = id
+	}
 	result["env"] = envMap
 
 	envKeys := make(map[string]struct{})

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -59,15 +59,15 @@ func newConverter(config *config, info *buildInfo) *converter {
 	return c
 }
 
-func (c *converter) convertStep(step map[string]any) (
+func (c *converter) convertStep(id string, step map[string]any) (
 	map[string]any, error,
 ) {
 	for _, stepConverter := range c.stepConverters {
 		if stepConverter.match(step) {
-			return stepConverter.convert(step)
+			return stepConverter.convert(id, step)
 		}
 	}
-	return c.defaultConverter.convert(step)
+	return c.defaultConverter.convert(id, step)
 }
 
 func (c *converter) convertGroup(n *stepNode) (
@@ -87,7 +87,7 @@ func (c *converter) convertGroup(n *stepNode) (
 		}
 
 		// convert step to buildkite step
-		bkStep, err := c.convertStep(step.src)
+		bkStep, err := c.convertStep(step.id, step.src)
 		if err != nil {
 			return nil, fmt.Errorf("convert pipeline step: %w", err)
 		}

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -88,6 +88,8 @@ func TestConvertPipelineStep(t *testing.T) {
 		gitCommit:      "abcdefg1234567890",
 	}
 
+	const fakeJobID = "fakeid"
+
 	c := newConverter(&config{
 		ArtifactsBucket: "artifacts_bucket",
 		CITemp:          "s3://ci-temp/",
@@ -133,6 +135,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -160,6 +163,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -181,6 +185,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -212,6 +217,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -273,6 +279,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -300,6 +307,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
+				"RAYCI_JOB_ID":              fakeJobID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -322,11 +330,13 @@ func TestConvertPipelineStep(t *testing.T) {
 			"retry":              defaultRayRetry,
 			"env": map[string]string{
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": "s3://artifacts_bucket/abcdefg1234567890",
-				"BUILDKITE_BAZEL_CACHE_URL":             "https://bazel-build-cache",
-				"RAYCI_BRANCH":                          "beta",
-				"RAYCI_BUILD_ID":                        "abc123",
-				"RAYCI_TEMP":                            "s3://ci-temp/abc123/",
-				"RAYCI_WORK_REPO":                       "fakeecr",
+
+				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
+				"RAYCI_BRANCH":              "beta",
+				"RAYCI_BUILD_ID":            "abc123",
+				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
+				"RAYCI_WORK_REPO":           "fakeecr",
+				"RAYCI_JOB_ID":              fakeJobID,
 			},
 		},
 	}, {
@@ -353,7 +363,7 @@ func TestConvertPipelineStep(t *testing.T) {
 			"depends_on": "dep", "if": "false",
 		},
 	}} {
-		got, err := c.convertStep(test.in)
+		got, err := c.convertStep("fakeid", test.in)
 		if err != nil {
 			t.Errorf("convertPipelineStep %+v: %v", test.in, err)
 			continue
@@ -441,6 +451,7 @@ func TestConvertPipelineStep(t *testing.T) {
 			"BUILDKITE_BAZEL_CACHE_URL",
 			"RAYCI_SCHEDULE",
 			"RAYCI_CHECKOUT_DIR",
+			"RAYCI_JOB_ID",
 		} {
 			if !findInSlice(envs, env) {
 				t.Errorf("convertPipelineStep %+v: no %q", test.in, env)

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -88,7 +88,7 @@ func TestConvertPipelineStep(t *testing.T) {
 		gitCommit:      "abcdefg1234567890",
 	}
 
-	const fakeJobID = "fakeid"
+	const fakeStepID = "fakeid"
 
 	c := newConverter(&config{
 		ArtifactsBucket: "artifacts_bucket",
@@ -135,7 +135,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -163,7 +163,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -185,7 +185,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -217,7 +217,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -279,7 +279,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -307,7 +307,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"BUILDKITE_BAZEL_CACHE_URL": "https://bazel-build-cache",
 				"RAYCI_WORK_REPO":           "fakeecr",
 				"RAYCI_BRANCH":              "beta",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 
 				"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": artifactDest,
 			},
@@ -336,7 +336,7 @@ func TestConvertPipelineStep(t *testing.T) {
 				"RAYCI_BUILD_ID":            "abc123",
 				"RAYCI_TEMP":                "s3://ci-temp/abc123/",
 				"RAYCI_WORK_REPO":           "fakeecr",
-				"RAYCI_JOB_ID":              fakeJobID,
+				"RAYCI_STEP_ID":             fakeStepID,
 			},
 		},
 	}, {
@@ -451,7 +451,7 @@ func TestConvertPipelineStep(t *testing.T) {
 			"BUILDKITE_BAZEL_CACHE_URL",
 			"RAYCI_SCHEDULE",
 			"RAYCI_CHECKOUT_DIR",
-			"RAYCI_JOB_ID",
+			"RAYCI_STEP_ID",
 		} {
 			if !findInSlice(envs, env) {
 				t.Errorf("convertPipelineStep %+v: no %q", test.in, env)

--- a/raycicmd/step_converter.go
+++ b/raycicmd/step_converter.go
@@ -9,7 +9,7 @@ type stepConverter interface {
 	match(step map[string]any) bool
 
 	// convert converts a step from the rayci format to the buildkite format.
-	convert(step map[string]any) (map[string]any, error)
+	convert(id string, step map[string]any) (map[string]any, error)
 }
 
 type basicStepConverter struct {
@@ -28,7 +28,7 @@ func (c *basicStepConverter) match(step map[string]any) bool {
 	return stepHasKey(step, c.signatureKey)
 }
 
-func (c *basicStepConverter) convert(step map[string]any) (
+func (c *basicStepConverter) convert(id string, step map[string]any) (
 	map[string]any, error,
 ) {
 	if err := checkStepKeys(step, c.allowedKeys); err != nil {

--- a/raycicmd/step_converter_test.go
+++ b/raycicmd/step_converter_test.go
@@ -32,7 +32,7 @@ func TestWaitConverter(t *testing.T) {
 			t.Errorf("cannot match wait step %+v", test.step)
 		}
 
-		got, err := waitConverter.convert(test.step)
+		got, err := waitConverter.convert("id", test.step)
 		if err != nil {
 			t.Errorf("convert %+v got error %v", test.step, err)
 			continue
@@ -70,7 +70,7 @@ func TestBlockConverter(t *testing.T) {
 			t.Errorf("cannot match wait step %+v", test.step)
 		}
 
-		got, err := blockConverter.convert(test.step)
+		got, err := blockConverter.convert("id", test.step)
 		if err != nil {
 			t.Errorf("convert %+v got error %v", test.step, err)
 			continue
@@ -121,7 +121,7 @@ func TestTriggerConverter(t *testing.T) {
 			"allow_dependency_failure": "true",
 		},
 	}} {
-		got, err := triggerConverter.convert(test.step)
+		got, err := triggerConverter.convert("id", test.step)
 		if err != nil {
 			t.Errorf("convert %+v got error %v", test.step, err)
 			continue

--- a/raycicmd/wanda.go
+++ b/raycicmd/wanda.go
@@ -138,7 +138,9 @@ func parseStepEnvs(v any) ([]*envEntry, error) {
 	return entries, nil
 }
 
-func (c *wandaConverter) convert(step map[string]any) (map[string]any, error) {
+func (c *wandaConverter) convert(id string, step map[string]any) (
+	map[string]any, error,
+) {
 	if err := checkStepKeys(step, wandaStepAllowedKeys); err != nil {
 		return nil, fmt.Errorf("check wanda step keys: %w", err)
 	}


### PR DESCRIPTION
so that the jobs of the step can know what step id they are using, and it is easier for human to tell too.