### PR TITLE
[ci] add RAYCI_BISECT_TEST_TARGET env key to postmerge pipeline

### DIFF
--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -200,8 +200,11 @@ var branchPipelineConfig = &config{
 		"BUILDKITE_BAZEL_CACHE_URL": rayBazelBuildCache,
 	},
 
-	BuildEnvKeys: []string{"RAYCI_SCHEDULE"},
-	HookEnvKeys:  []string{"RAYCI_CHECKOUT_DIR"},
+	BuildEnvKeys: []string{
+		"RAYCI_SCHEDULE",
+		"RAYCI_BISECT_TEST_TARGET",
+	},
+	HookEnvKeys: []string{"RAYCI_CHECKOUT_DIR"},
 
 	SkipTags: []string{"disabled"},
 }

--- a/raycicmd/config_test.go
+++ b/raycicmd/config_test.go
@@ -21,6 +21,15 @@ func TestLoadConfig(t *testing.T) {
 		if want := "ray-branch"; config.name != want {
 			t.Errorf("config got %q, want %q", config.name, want)
 		}
+		envHasKey := false
+		for _, value := range config.BuildEnvKeys {
+			if value == "RAYCI_BISECT_TEST_TARGET" {
+				envHasKey = true
+			}
+		}
+		if !envHasKey {
+			t.Errorf("config does not have key RAYCI_BISECT_TEST_TARGET")
+		}
 	})
 
 	t.Run("load ray PR CI config", func(t *testing.T) {


### PR DESCRIPTION
I plan to reuse the `postmerge` pipeline to create a build that can run one test target (for bisecting purpose). Add an env variable I can pass down to a step to run only a single test target.