### PR TITLE
[rayci] pass RAYCI_BISECT_TEST_TARGET to docker plugin environment

### DIFF
--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -450,6 +450,7 @@ func TestConvertPipelineStep(t *testing.T) {
 			"RAYCI_WORK_REPO",
 			"BUILDKITE_BAZEL_CACHE_URL",
 			"RAYCI_SCHEDULE",
+			"RAYCI_BISECT_TEST_TARGET",
 			"RAYCI_CHECKOUT_DIR",
 			"RAYCI_STEP_ID",
 		} {


### PR DESCRIPTION
https://github.com/ray-project/rayci/commit/5ff677f9044619acce14add77c3c90b4f08c4ea7 added `RAYCI_BISECT_TEST_TARGET` to the buildkite build environment list. I also need to pass this to the docker plugin environment list for the step applications to use this value.