### PR TITLE
[rayci] add a flag to disable parallelism in buildkite definition

### DIFF
--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -3,6 +3,7 @@ package raycicmd
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -93,8 +94,16 @@ func (c *commandConverter) convert(id string, step map[string]any) (
 		result["priority"] = priority
 	}
 
-	if _, ok := step["parallelism"]; ok && c.config.DisableParallelism {
-		result["parallelism"] = 1
+	parallelism, ok := step["parallelism"]
+	if ok && c.config.MaxParallelism > 0 {
+		maxParallelism := c.config.MaxParallelism
+		parallelism, err := strconv.Atoi(fmt.Sprintf("%v", parallelism))
+		if err != nil {
+			return nil, fmt.Errorf("convert parallelism: %w", err)
+		}
+		if parallelism > maxParallelism {
+			result["parallelism"] = maxParallelism
+		}
 	}
 
 	envMap := copyEnvMap(c.envMap)

--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -93,6 +93,10 @@ func (c *commandConverter) convert(id string, step map[string]any) (
 		result["priority"] = priority
 	}
 
+	if _, ok := step["parallelism"]; ok && c.config.DisableParallelism {
+		result["parallelism"] = 1
+	}
+
 	envMap := copyEnvMap(c.envMap)
 	if id != "" {
 		envMap["RAYCI_STEP_ID"] = id


### PR DESCRIPTION
Disable it by setting it to 1 (instead of just removing the line), because the command definition expects the `BUILDKITE_PARALLEL_JOB_COUNT` environment to be set. This is so that we can turn this off on microcheck.

Test:
- CI