### PR TITLE
[rayci] allow to restrict the list of concurrency group

### DIFF
--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -74,20 +74,16 @@ func (c *commandConverter) convert(id string, step map[string]any) (
 	if err != nil {
 		return nil, fmt.Errorf("map agent: %w", err)
 	}
-	concurrency_group, _ := stringInMap(step, "concurrency_group")
-	allowed_concurrency_group := c.config.AllowConcurrencyGroup
-	if concurrency_group != "" && allowed_concurrency_group != nil {
-		allowed_group := false
-		for _, group := range allowed_concurrency_group {
-			if group == concurrency_group {
-				allowed_group = true
+	// We treat nil and empty allowConcurrencyGroupPrefixes differently. A nil value
+	// means that we don't have any restrictions on the concurrency group. An empty
+	// value means that we don't allow any concurrency group.
+	if group, ok := stringInMap(step, "concurrency_group"); ok {
+		if prefixes := c.config.AllowConcurrencyGroupPrefixes; prefixes != nil {
+			if !stringHasPrefix(group, prefixes) {
+				return nil, fmt.Errorf("concurrency group %q is not allowed", group)
 			}
 		}
-		if !allowed_group {
-			return nil, fmt.Errorf("concurrency group %q is not allowed", concurrency_group)
-		}
 	}
-
 	result := cloneMapExcept(step, commandStepDropKeys)
 
 	if agentQueue != skipQueue { // queue type not supported, skip.

--- a/raycicmd/command_step.go
+++ b/raycicmd/command_step.go
@@ -74,6 +74,19 @@ func (c *commandConverter) convert(id string, step map[string]any) (
 	if err != nil {
 		return nil, fmt.Errorf("map agent: %w", err)
 	}
+	concurrency_group, _ := stringInMap(step, "concurrency_group")
+	allowed_concurrency_group := c.config.AllowConcurrencyGroup
+	if concurrency_group != "" && allowed_concurrency_group != nil {
+		allowed_group := false
+		for _, group := range allowed_concurrency_group {
+			if group == concurrency_group {
+				allowed_group = true
+			}
+		}
+		if !allowed_group {
+			return nil, fmt.Errorf("concurrency group %q is not allowed", concurrency_group)
+		}
+	}
 
 	result := cloneMapExcept(step, commandStepDropKeys)
 

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -119,6 +119,12 @@ type config struct {
 	// Optional.
 	AllowTriggerStep bool `yaml:"allow_trigger_step"`
 
+	// AllowConcurrencyGroup is the list of concurrency group names that are
+	// allowed for the pipeline.
+	//
+	// Optional.
+	AllowConcurrencyGroup []string `yaml:"allow_concurrency_group"`
+
 	// MaxParallelism is the maximum number of parallel jobs that can be run in
 	// the pipeline. If a bigger number of parallelism is requested, it will be
 	// capped to this number.
@@ -272,6 +278,8 @@ func prPipelineConfig(
 		TagFilterCommand: []string{"./ci/ci_tags_from_change.sh"},
 
 		SkipTags: []string{"disabled", "skip-on-premerge"},
+
+		AllowConcurrencyGroup: []string{},
 	}
 	for k, v := range extraEnv {
 		config.Env[k] = v

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -120,7 +120,7 @@ type config struct {
 	AllowTriggerStep bool `yaml:"allow_trigger_step"`
 
 	// AllowConcurrencyGroup is the list of concurrency group names that are
-	// allowed for the pipeline.
+	// allowed for the pipeline. If not set, all concurrency groups are allowed.
 	//
 	// Optional.
 	AllowConcurrencyGroup []string `yaml:"allow_concurrency_group"`

--- a/raycicmd/config.go
+++ b/raycicmd/config.go
@@ -119,11 +119,12 @@ type config struct {
 	// Optional.
 	AllowTriggerStep bool `yaml:"allow_trigger_step"`
 
-	// AllowConcurrencyGroup is the list of concurrency group names that are
-	// allowed for the pipeline. If not set, all concurrency groups are allowed.
+	// AllowConcurrencyGroup is the list of concurrency group name prefixes that are
+	// allowed for the pipeline. If not set or set to NULL, all concurrency group names
+	// are allowed.
 	//
 	// Optional.
-	AllowConcurrencyGroup []string `yaml:"allow_concurrency_group"`
+	AllowConcurrencyGroupPrefixes []string `yaml:"allow_concurrency_group_prefixes"`
 
 	// MaxParallelism is the maximum number of parallel jobs that can be run in
 	// the pipeline. If a bigger number of parallelism is requested, it will be
@@ -279,7 +280,7 @@ func prPipelineConfig(
 
 		SkipTags: []string{"disabled", "skip-on-premerge"},
 
-		AllowConcurrencyGroup: []string{},
+		AllowConcurrencyGroupPrefixes: []string{},
 	}
 	for k, v := range extraEnv {
 		config.Env[k] = v

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -80,6 +80,37 @@ func findInSlice(s []string, v string) bool {
 	return false
 }
 
+func TestConvertPipelineStep_concurrency_group(t *testing.T) {
+	const buildID = "abc123"
+	info := &buildInfo{
+		buildID:        buildID,
+		launcherBranch: "beta",
+		gitCommit:      "abcdefg1234567890",
+	}
+
+	c := newConverter(&config{
+		ArtifactsBucket: "artifacts_bucket",
+		CITemp:          "s3://ci-temp/",
+		CIWorkRepo:      "fakeecr",
+		RunnerQueues: map[string]string{
+			"default": "fakerunner",
+		},
+		AllowConcurrencyGroup: []string{},
+	}, info)
+
+	step := map[string]any{
+		"label":             "say hello",
+		"key":               "key",
+		"command":           "echo hello",
+		"concurrency":       2,
+		"concurrency_group": "group",
+	}
+	_, err := c.convertStep("fakeid", step)
+	if err == nil {
+		t.Errorf("TestConvertPipelineStep_concurrency_group %+v: step concurrent group should not be allowed", step)
+	}
+}
+
 func TestConvertPipelineStep(t *testing.T) {
 	const buildID = "abc123"
 	info := &buildInfo{

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -95,7 +95,7 @@ func TestConvertPipelineStep_concurrency_group(t *testing.T) {
 		RunnerQueues: map[string]string{
 			"default": "fakerunner",
 		},
-		AllowConcurrencyGroup: []string{},
+		AllowConcurrencyGroupPrefixes: []string{"not_group"},
 	}, info)
 
 	step := map[string]any{
@@ -105,8 +105,7 @@ func TestConvertPipelineStep_concurrency_group(t *testing.T) {
 		"concurrency":       2,
 		"concurrency_group": "group",
 	}
-	_, err := c.convertStep("fakeid", step)
-	if err == nil {
+	if _, err := c.convertStep("fakeid", step); err == nil {
 		t.Errorf("TestConvertPipelineStep_concurrency_group %+v: step concurrent group should not be allowed", step)
 	}
 }

--- a/raycicmd/util.go
+++ b/raycicmd/util.go
@@ -2,6 +2,7 @@ package raycicmd
 
 import (
 	"fmt"
+	"strings"
 )
 
 func boolInMap(m map[string]any, key string) (bool, bool) {
@@ -11,6 +12,15 @@ func boolInMap(m map[string]any, key string) (bool, bool) {
 	}
 	b, ok := v.(bool)
 	return b, ok
+}
+
+func stringHasPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func stringInMap(m map[string]any, key string) (string, bool) {

--- a/raycicmd/util_test.go
+++ b/raycicmd/util_test.go
@@ -43,6 +43,38 @@ func TestBoolInMap(t *testing.T) {
 	}
 }
 
+func TestStringHasPrefix(t *testing.T) {
+	for _, test := range []struct {
+		str      string
+		prefixes []string
+		want     bool
+	}{{
+		str:      "abc",
+		prefixes: []string{"a"},
+		want:     true,
+	}, {
+		str:      "",
+		prefixes: []string{},
+		want:     false,
+	}, {
+		str:      "abc",
+		prefixes: []string{""},
+		want:     true,
+	}, {
+		str:      "def",
+		prefixes: []string{"a"},
+		want:     false,
+	}} {
+		got := stringHasPrefix(test.str, test.prefixes)
+		if got != test.want {
+			t.Errorf(
+				"stringHasPrefix(%q, %v): got %v, want %v",
+				test.str, test.prefixes, got, test.want,
+			)
+		}
+	}
+}
+
 func TestStringInMap(t *testing.T) {
 	for _, test := range []struct {
 		m    map[string]any


### PR DESCRIPTION
- Allow to restrict the list of concurrency group; or allow everything if the restricted list is not provided
- Restrict the list of concurrency group for premerge and microcheck (empty list means that the concurrency group is not allowed)

Test:
- CI