### PR TITLE
Updating epoch to include 2 groups for each week

### DIFF
--- a/wanda/cache_epoch.go
+++ b/wanda/cache_epoch.go
@@ -10,8 +10,8 @@ var sfoAround = time.FixedZone("SFO", -7*60*60)
 func defaultCacheEpoch(nowFunc func() time.Time) string {
 	now := nowFunc().In(sfoAround)
 	// When it is Sunday, we use the next week's epoch.
-	year, week := now.Add(24 * time.Hour).ISOWeek()
-	return fmt.Sprintf("%d%02d", year, week)
+	expiry := now.Add(3 * 24 * time.Hour)
+	return fmt.Sprintf("%d%03d", expiry.Year(), expiry.YearDay())
 }
 
 // DefaultCacheEpoch returns the default cache epoch.

--- a/wanda/cache_epoch.go
+++ b/wanda/cache_epoch.go
@@ -9,6 +9,7 @@ var sfoAround = time.FixedZone("SFO", -7*60*60)
 
 func defaultCacheEpoch(nowFunc func() time.Time) string {
 	now := nowFunc().In(sfoAround)
+	// splitting the week into 2 groups to prevent exceeding Container Registry's 1000 tag limit
 	var group string
 	if now.Weekday() < time.Thursday {
 		group = "a"

--- a/wanda/cache_epoch.go
+++ b/wanda/cache_epoch.go
@@ -9,9 +9,15 @@ var sfoAround = time.FixedZone("SFO", -7*60*60)
 
 func defaultCacheEpoch(nowFunc func() time.Time) string {
 	now := nowFunc().In(sfoAround)
-	// When it is Sunday, we use the next week's epoch.
-	expiry := now.Add(3 * 24 * time.Hour)
-	return fmt.Sprintf("%d%03d", expiry.Year(), expiry.YearDay())
+	var group string
+	if now.Weekday() < time.Thursday {
+		group = "A"
+	} else {
+		group = "B"
+	}
+
+	year, week := now.Add(24 * time.Hour).ISOWeek()
+	return fmt.Sprintf("%d%02d%s", year, week, group)
 }
 
 // DefaultCacheEpoch returns the default cache epoch.

--- a/wanda/cache_epoch.go
+++ b/wanda/cache_epoch.go
@@ -9,7 +9,7 @@ var sfoAround = time.FixedZone("SFO", -7*60*60)
 
 func defaultCacheEpoch(nowFunc func() time.Time) string {
 	now := nowFunc().In(sfoAround)
-	// splitting the week into 2 groups to prevent exceeding Container Registry's 1000 tag limit
+	// Splitting the week into 2 groups to prevent exceeding Container Registry's 1000 tag limit
 	var group string
 	if now.Weekday() < time.Thursday {
 		group = "a"

--- a/wanda/cache_epoch.go
+++ b/wanda/cache_epoch.go
@@ -11,9 +11,9 @@ func defaultCacheEpoch(nowFunc func() time.Time) string {
 	now := nowFunc().In(sfoAround)
 	var group string
 	if now.Weekday() < time.Thursday {
-		group = "A"
+		group = "a"
 	} else {
-		group = "B"
+		group = "b"
 	}
 
 	year, week := now.Add(24 * time.Hour).ISOWeek()

--- a/wanda/cache_epoch_test.go
+++ b/wanda/cache_epoch_test.go
@@ -17,19 +17,35 @@ func TestDefaultCacheEpoch(t *testing.T) {
 	}{{
 		name:     "saturday",
 		now:      morningOf(2025, time.May, 31), // Saturday
-		expected: "2025154",
+		expected: "202522B",
 	}, {
 		name:     "sunday",
 		now:      morningOf(2025, time.June, 1), // Sunday
-		expected: "2025155",
+		expected: "202523A",
 	}, {
 		name:     "monday",
 		now:      morningOf(2025, time.June, 2), // Monday
-		expected: "2025156",
+		expected: "202523A",
+	}, {
+		name:     "tuesday",
+		now:      morningOf(2025, time.June, 3), // Tuesday
+		expected: "202523A",
+	}, {
+		name:     "wednesday",
+		now:      morningOf(2025, time.June, 4), // Wednesday
+		expected: "202523A",
+	}, {
+		name:     "thursday",
+		now:      morningOf(2025, time.June, 5), // Thursday
+		expected: "202523B",
+	}, {
+		name:     "friday",
+		now:      morningOf(2025, time.June, 6), // Friday
+		expected: "202523B",
 	}, {
 		name:     "year boundary",
 		now:      morningOf(2023, time.December, 31), // Sunday
-		expected: "2024003",
+		expected: "202401A",                          // First full week of 2024
 	}}
 
 	for _, test := range tests {

--- a/wanda/cache_epoch_test.go
+++ b/wanda/cache_epoch_test.go
@@ -17,35 +17,35 @@ func TestDefaultCacheEpoch(t *testing.T) {
 	}{{
 		name:     "saturday",
 		now:      morningOf(2025, time.May, 31), // Saturday
-		expected: "202522B",
+		expected: "202522b",
 	}, {
 		name:     "sunday",
 		now:      morningOf(2025, time.June, 1), // Sunday
-		expected: "202523A",
+		expected: "202523a",
 	}, {
 		name:     "monday",
 		now:      morningOf(2025, time.June, 2), // Monday
-		expected: "202523A",
+		expected: "202523a",
 	}, {
 		name:     "tuesday",
 		now:      morningOf(2025, time.June, 3), // Tuesday
-		expected: "202523A",
+		expected: "202523a",
 	}, {
 		name:     "wednesday",
 		now:      morningOf(2025, time.June, 4), // Wednesday
-		expected: "202523A",
+		expected: "202523a",
 	}, {
 		name:     "thursday",
 		now:      morningOf(2025, time.June, 5), // Thursday
-		expected: "202523B",
+		expected: "202523b",
 	}, {
 		name:     "friday",
 		now:      morningOf(2025, time.June, 6), // Friday
-		expected: "202523B",
+		expected: "202523b",
 	}, {
 		name:     "year boundary",
 		now:      morningOf(2023, time.December, 31), // Sunday
-		expected: "202401A",                          // First full week of 2024
+		expected: "202401a",                          // First full week of 2024
 	}}
 
 	for _, test := range tests {

--- a/wanda/cache_epoch_test.go
+++ b/wanda/cache_epoch_test.go
@@ -17,19 +17,19 @@ func TestDefaultCacheEpoch(t *testing.T) {
 	}{{
 		name:     "saturday",
 		now:      morningOf(2025, time.May, 31), // Saturday
-		expected: "202522",
+		expected: "2025154",
 	}, {
 		name:     "sunday",
 		now:      morningOf(2025, time.June, 1), // Sunday
-		expected: "202523",
+		expected: "2025155",
 	}, {
 		name:     "monday",
 		now:      morningOf(2025, time.June, 2), // Monday
-		expected: "202523",
+		expected: "2025156",
 	}, {
 		name:     "year boundary",
 		now:      morningOf(2023, time.December, 31), // Sunday
-		expected: "202401",                           // First full week of 2024
+		expected: "2024003",
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Splitting epoch week into group A & group B (and appending to the epoch) due to exceeding container registry's 1000 tag limit intermittently