### PR TITLE
[wanda] add `disable_caching` option

### DIFF
--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -170,6 +170,8 @@ func (f *Forge) Build(spec *Spec) error {
 	}
 	inputCore.Epoch = f.config.Epoch
 
+	caching := !spec.DisableCaching
+
 	inputDigest, err := inputCore.digest()
 	if err != nil {
 		return fmt.Errorf("compute build input digest: %w", err)
@@ -199,7 +201,7 @@ func (f *Forge) Build(spec *Spec) error {
 		}
 	}
 
-	if !f.config.Rebuild {
+	if caching && !f.config.Rebuild {
 		if f.isRemote() {
 			ct, err := cranename.NewTag(cacheTag)
 			if err != nil {
@@ -264,7 +266,7 @@ func (f *Forge) Build(spec *Spec) error {
 		}
 
 		// Save cache result too.
-		if !f.config.ReadOnlyCache {
+		if caching && !f.config.ReadOnlyCache {
 			if err := d.run("push", cacheTag); err != nil {
 				return fmt.Errorf("push cache: %w", err)
 			}

--- a/wanda/spec.go
+++ b/wanda/spec.go
@@ -25,6 +25,9 @@ type Spec struct {
 	// in cache input compute. The value of these build args should not
 	// change the output of the build.
 	BuildHintArgs []string `yaml:"build_hint_args,omitempty"`
+
+	// DisableCaching disables use of caching.
+	DisableCaching bool `yaml:"disable_caching,omitempty"`
 }
 
 func parseSpecFile(f string) (*Spec, error) {

--- a/wanda/testdata/hello-nocache.wanda.yaml
+++ b/wanda/testdata/hello-nocache.wanda.yaml
@@ -1,0 +1,3 @@
+name: hello
+dockerfile: Dockerfile.hello
+disable_caching: true


### PR DESCRIPTION
allows running a wanda build without caching enabled. this helps on building images which contents are fast to build but changing frequently. if these images are cached, it can spam the container registry and make the registry run out of image count quota if it is an ECR.