### PR TITLE
[ci] dont run array-test in postmerge

### DIFF
--- a/.buildkite/array-test.rayci.yaml
+++ b/.buildkite/array-test.rayci.yaml
@@ -8,6 +8,10 @@ steps:
     key: array-step
     command: |
       echo "Running os={{array.os}} variant={{array.variant}}"
+      if [ "${RAYCI_STAGE:-}" = "postmerge" ]; then
+        echo "Postmerge: skipping filter assertions"
+        exit 0
+      fi
       if [ "{{array.os}}" != "linux" ] && [ "{{array.os}}" != "macos" ]; then
         echo "ERROR: unexpected os={{array.os}}"
         exit 1

--- a/.buildkite/array-test.rayci.yaml
+++ b/.buildkite/array-test.rayci.yaml
@@ -6,12 +6,9 @@ steps:
   # when filtered (others are skipped)
   - label: "Array {{array.os}}-{{array.variant}}"
     key: array-step
+    if: build.env("RAYCI_STAGE") != "postmerge"
     command: |
       echo "Running os={{array.os}} variant={{array.variant}}"
-      if [ "${RAYCI_STAGE:-}" = "postmerge" ]; then
-        echo "Postmerge: skipping filter assertions"
-        exit 0
-      fi
       if [ "{{array.os}}" != "linux" ] && [ "{{array.os}}" != "macos" ]; then
         echo "ERROR: unexpected os={{array.os}}"
         exit 1


### PR DESCRIPTION
Postmerge runs all tests, regardless of filters. We want to skip these, since they will purposefully fail when triggered to validate the array feature.