### PR TITLE
[wanda] Handle scratch as a built-in FROM image

### DIFF
--- a/wanda/deps_test.go
+++ b/wanda/deps_test.go
@@ -465,6 +465,78 @@ func TestBuildDepGraph_ExternalDep(t *testing.T) {
 	}
 }
 
+func TestBuildDepGraph_OptionalFromViaEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	specsFile := writeWandaSpecs(t, tmpDir, []string{"."})
+
+	// "java" is a wanda-built dependency that can be swapped out
+	// via an environment variable.
+	writeSpec(t, tmpDir, "java.wanda.yaml", strings.Join([]string{
+		"name: java",
+		"dockerfile: Dockerfile",
+	}, "\n"))
+
+	// "wheel" depends on java via $JAVA_IMAGE.
+	// When JAVA_IMAGE points to the wanda-built image, java is a dependency.
+	// When JAVA_IMAGE is set to "scratch", there is no wanda dependency.
+	writeSpec(t, tmpDir, "wheel.wanda.yaml", strings.Join([]string{
+		"name: wheel",
+		`froms: ["$JAVA_IMAGE"]`,
+		"dockerfile: Dockerfile",
+		"build_args:",
+		"  - JAVA_IMAGE",
+	}, "\n"))
+
+	t.Run("wanda dep when pointing to prefixed image", func(t *testing.T) {
+		lookup := func(key string) (string, bool) {
+			if key == "JAVA_IMAGE" {
+				return "cr.ray.io/rayproject/java", true
+			}
+			return "", false
+		}
+
+		graph, err := buildDepGraph(
+			filepath.Join(tmpDir, "wheel.wanda.yaml"),
+			lookup, testPrefix, specsFile,
+		)
+		if err != nil {
+			t.Fatalf("buildDepGraph: %v", err)
+		}
+
+		if len(graph.Order) != 2 {
+			t.Fatalf("Order = %v, want 2 specs", graph.Order)
+		}
+		if graph.Specs["java"] == nil {
+			t.Error("expected java in graph as a wanda dependency")
+		}
+	})
+
+	t.Run("no wanda dep when set to scratch", func(t *testing.T) {
+		lookup := func(key string) (string, bool) {
+			if key == "JAVA_IMAGE" {
+				return "scratch", true
+			}
+			return "", false
+		}
+
+		graph, err := buildDepGraph(
+			filepath.Join(tmpDir, "wheel.wanda.yaml"),
+			lookup, testPrefix, specsFile,
+		)
+		if err != nil {
+			t.Fatalf("buildDepGraph: %v", err)
+		}
+
+		if len(graph.Order) != 1 {
+			t.Fatalf("Order = %v, want only wheel", graph.Order)
+		}
+		if graph.Specs["java"] != nil {
+			t.Error("java should not be in graph when JAVA_IMAGE=scratch")
+		}
+	})
+}
+
 func TestBuildDepGraph_TransitiveDeps(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -175,11 +175,27 @@ func (f *Forge) newDockerCmd() *dockerCmd {
 	})
 }
 
+// isDockerScratch reports whether s is Docker's built-in empty base image.
+// "scratch" is not a real registry image; Docker handles it as a special
+// keyword in FROM instructions, so it must not be pulled or resolved.
+func isDockerScratch(s string) bool {
+	return s == "scratch"
+}
+
 func (f *Forge) resolveBases(froms []string) (map[string]*imageSource, error) {
 	m := make(map[string]*imageSource)
 	namePrefix := f.config.NamePrefix
 
 	for _, from := range froms {
+		if isDockerScratch(from) {
+			m[from] = &imageSource{
+				name:  from,
+				id:    from,
+				local: from,
+			}
+			continue
+		}
+
 		if strings.HasPrefix(from, "@") { // A local image.
 			name := strings.TrimPrefix(from, "@")
 			src, err := resolveDockerImage(f.docker, from, name)

--- a/wanda/forge_test.go
+++ b/wanda/forge_test.go
@@ -848,6 +848,19 @@ func TestBuild_EnvfileCacheInvalidation(t *testing.T) {
 	}
 }
 
+func TestBuild_ScratchFrom(t *testing.T) {
+	t.Setenv("OPTIONAL_IMAGE", "scratch")
+
+	config := &ForgeConfig{
+		WorkDir:    "testdata",
+		NamePrefix: "cr.ray.io/rayproject/",
+	}
+
+	if err := Build("testdata/scratch-from.wanda.yaml", config); err != nil {
+		t.Fatalf("build with scratch from: %v", err)
+	}
+}
+
 func TestForgeConfigArtifactsDir(t *testing.T) {
 	config := &ForgeConfig{ArtifactsDir: "/custom/artifacts", WorkDir: "/work"}
 	if got := config.ArtifactsDir; got != "/custom/artifacts" {
@@ -1211,7 +1224,12 @@ func TestTargetOS(t *testing.T) {
 
 func TestCheckPlatformSupport(t *testing.T) {
 	if err := checkPlatformSupport(); err != nil {
-		t.Errorf("checkPlatformSupport() on %s/%s = %v, want nil", runtime.GOOS, runtime.GOARCH, err)
+		t.Errorf(
+			"checkPlatformSupport() on %s/%s = %v, want nil",
+			runtime.GOOS,
+			runtime.GOARCH,
+			err,
+		)
 	}
 }
 

--- a/wanda/testdata/Dockerfile.scratch-from
+++ b/wanda/testdata/Dockerfile.scratch-from
@@ -1,0 +1,4 @@
+ARG OPTIONAL_IMAGE=scratch
+FROM ${OPTIONAL_IMAGE} AS optional
+FROM scratch
+COPY Dockerfile.scratch-from /opt/Dockerfile

--- a/wanda/testdata/scratch-from.wanda.yaml
+++ b/wanda/testdata/scratch-from.wanda.yaml
@@ -1,0 +1,6 @@
+name: scratch-from-test
+froms:
+  - "$OPTIONAL_IMAGE"
+dockerfile: Dockerfile.scratch-from
+build_args:
+  - OPTIONAL_IMAGE


### PR DESCRIPTION
When a wanda spec uses "scratch" in froms (e.g. via an env var set to "scratch" to disable an optional dependency), wanda tried to pull it from Docker Hub as a remote image. Since scratch is a Docker built-in pseudo-image that doesn't exist in any registry, the pull failed with MANIFEST_UNKNOWN.

https://buildkite.com/ray-project/premerge/builds/64091/steps/canvas?sid=019d7849-3605-4a37-9aab-bcb3255fe01f&tab=output#019d7859-6aed-462c-9475-b44b312c9a7b/L176
>  [2026-04-10T17:04:51Z] 2026/04/10 17:04:51 build ray-wheel-py3.13: resolve bases: resolve remote image scratch: fetch image scratch: GET https://index.docker.io/v2/library/scratch/manifests/latest: MANIFEST_UNKNOWN: manifest unknown; unknown tag=latest

Skip remote resolution for scratch and treat it as an already-available local image, matching Docker's own handling of FROM scratch.

Topic: optional-wanda

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>