### PR TITLE
[rayci] Expand bare array base keys in RAYCI_SELECT

### DIFF
--- a/raycicmd/array_expand.go
+++ b/raycicmd/array_expand.go
@@ -8,7 +8,10 @@ import (
 
 // expandArraySteps expands array steps into resolvedSteps and resolves
 // depends_on references to point to the expanded keys.
-func expandArraySteps(gs []*pipelineGroup) error {
+// Returns the configs map so callers can resolve array selectors.
+func expandArraySteps(
+	gs []*pipelineGroup,
+) (map[string]*arrayConfig, error) {
 	configs := make(map[string]*arrayConfig)
 	// elems maps each expanded step key to its arrayElement,
 	// used for implicit dimension matching in Pass 2.
@@ -17,7 +20,7 @@ func expandArraySteps(gs []*pipelineGroup) error {
 	// Pass 1: expand array steps into resolvedSteps.
 	for _, g := range gs {
 		if err := g.buildResolvedSteps(configs, elems); err != nil {
-			return fmt.Errorf("expand arrays: %w", err)
+			return nil, fmt.Errorf("expand arrays: %w", err)
 		}
 	}
 
@@ -33,7 +36,7 @@ func expandArraySteps(gs []*pipelineGroup) error {
 				dependsOn, configs, currentElem,
 			)
 			if err != nil {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"resolve depends_on for step %q: %w",
 					stepKey(rs.src), err,
 				)
@@ -52,7 +55,7 @@ func expandArraySteps(gs []*pipelineGroup) error {
 			g.DependsOn, configs,
 		)
 		if err != nil {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"resolve depends_on for group %q: %w",
 				g.Group, err,
 			)
@@ -60,7 +63,7 @@ func expandArraySteps(gs []*pipelineGroup) error {
 		g.DependsOn = resolved
 	}
 
-	return nil
+	return configs, nil
 }
 
 // buildResolvedSteps populates g.resolvedSteps from g.Steps, expanding

--- a/raycicmd/array_expand_test.go
+++ b/raycicmd/array_expand_test.go
@@ -18,7 +18,7 @@ func TestExpandArraySteps(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -49,7 +49,7 @@ func TestExpandArraySteps_DoesNotMutateSrc(t *testing.T) {
 		Steps: []map[string]any{origStep},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -78,7 +78,7 @@ func TestExpandArraySteps_LabelPlaceholderRequired(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for missing placeholder, got nil")
 	}
@@ -105,7 +105,7 @@ func TestExpandArraySteps_MatrixAndArrayMutuallyExclusive(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for both matrix and array, got nil")
 	}
@@ -140,7 +140,7 @@ func TestExpandArraySteps_SelectorDependsOn(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -164,8 +164,12 @@ func TestExpandArraySteps_SelectorDependsOn(t *testing.T) {
 	if len(partialDeps) != 2 {
 		t.Fatalf("partial selector: got %d deps, want 2: %v", len(partialDeps), partialDeps)
 	}
-	if partialDeps[0] != "build-step--cuda1211-python311" || partialDeps[1] != "build-step--cuda1281-python311" {
-		t.Errorf("partial selector: got %v, want [build-step--cuda1211-python311, build-step--cuda1281-python311]", partialDeps)
+	if partialDeps[0] != "build-step--cuda1211-python311" ||
+		partialDeps[1] != "build-step--cuda1281-python311" {
+		t.Errorf(
+			"partial selector: got %v, want [build-step--cuda1211-python311, build-step--cuda1281-python311]",
+			partialDeps,
+		)
 	}
 }
 
@@ -189,7 +193,7 @@ func TestExpandArraySteps_MatchAllDependsOn(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -200,7 +204,10 @@ func TestExpandArraySteps_MatchAllDependsOn(t *testing.T) {
 		t.Fatalf("got %d deps, want 2: %v", len(resolved), resolved)
 	}
 	if resolved[0] != "build-step--python310" || resolved[1] != "build-step--python311" {
-		t.Errorf("resolved deps: got %v, want [build-step--python310, build-step--python311]", resolved)
+		t.Errorf(
+			"resolved deps: got %v, want [build-step--python310, build-step--python311]",
+			resolved,
+		)
 	}
 }
 
@@ -220,7 +227,7 @@ func TestExpandArraySteps_SelectorOnNonArrayStep(t *testing.T) {
 				}},
 			}}
 
-			err := expandArraySteps(groups)
+			_, err := expandArraySteps(groups)
 			if err == nil {
 				t.Fatal("expected error for array selector on non-array step, got nil")
 			}
@@ -241,7 +248,7 @@ func TestExpandArraySteps_NonArrayDependsOn(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -272,7 +279,7 @@ func TestExpandArraySteps_SkipAdjustment(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -308,7 +315,7 @@ func TestExpandArraySteps_AddAdjustment(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -346,7 +353,7 @@ func TestExpandArraySteps_AddToSingleElementProduct(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -394,7 +401,7 @@ func TestExpandArraySteps_DependsOnExcludesSkipped(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -440,7 +447,7 @@ func TestExpandArraySteps_DependsOnIncludesAdded(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -481,7 +488,7 @@ func TestExpandArraySteps_SkipNoMatch(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for skip with no match, got nil")
 	}
@@ -509,7 +516,7 @@ func TestExpandArraySteps_AddMissingDimension(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for addition missing dimension, got nil")
 	}
@@ -541,7 +548,7 @@ func TestExpandArraySteps_GroupDependsOnArrayStep(t *testing.T) {
 		},
 	}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -583,7 +590,7 @@ func TestExpandArraySteps_GroupDependsOnNonArrayStep(t *testing.T) {
 		},
 	}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -688,7 +695,7 @@ func TestExpandArraySteps_ImplicitMatch(t *testing.T) {
 				},
 			}}
 
-			if err := expandArraySteps(groups); err != nil {
+			if _, err := expandArraySteps(groups); err != nil {
 				t.Fatalf("expandArraySteps() error = %v", err)
 			}
 
@@ -757,7 +764,7 @@ func TestExpandArraySteps_ImplicitMatchNoOverlapError(t *testing.T) {
 		},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for ($) with no overlap, got nil")
 	}
@@ -806,7 +813,7 @@ func TestExpandArraySteps_ImplicitMatchMixedDeps(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -887,7 +894,7 @@ func TestExpandArraySteps_ExplicitSelectorOverridesImplicit(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -980,7 +987,7 @@ func TestExpandArraySteps_ImplicitMatchPublishScenario(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -1109,7 +1116,7 @@ func TestExpandArraySteps_ImplicitMatchWithAdjustments(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -1177,7 +1184,7 @@ func TestExpandArraySteps_MatchAllFromArrayStep(t *testing.T) {
 		},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -1225,7 +1232,7 @@ func TestExpandArraySteps_ImplicitMatchValueMismatchError(t *testing.T) {
 		},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for value mismatch, got nil")
 	}
@@ -1269,7 +1276,7 @@ func TestExpandArraySteps_DuplicateBaseKey(t *testing.T) {
 		},
 	}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for duplicate base key, got nil")
 	}
@@ -1299,7 +1306,7 @@ func TestExpandArraySteps_DuplicateElementFromAdjustment(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for duplicate element, got nil")
 	}
@@ -1326,7 +1333,7 @@ func TestExpandArraySteps_KeyCollisionFromSanitization(t *testing.T) {
 		}},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for key collision, got nil")
 	}
@@ -1360,7 +1367,7 @@ func TestExpandArraySteps_PartialDimensionSkip(t *testing.T) {
 		}},
 	}}
 
-	if err := expandArraySteps(groups); err != nil {
+	if _, err := expandArraySteps(groups); err != nil {
 		t.Fatalf("expandArraySteps() error = %v", err)
 	}
 
@@ -1397,7 +1404,7 @@ func TestExpandArraySteps_PlainStringTargetsArrayStep(t *testing.T) {
 		},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for plain depends_on targeting array step, got nil")
 	}
@@ -1429,7 +1436,7 @@ func TestExpandArraySteps_ImplicitFromNonArrayStepError(t *testing.T) {
 		},
 	}}
 
-	err := expandArraySteps(groups)
+	_, err := expandArraySteps(groups)
 	if err == nil {
 		t.Fatal("expected error for ($) from non-array step, got nil")
 	}
@@ -1483,7 +1490,7 @@ func TestExpandArraySteps_GroupDependsOnSelector(t *testing.T) {
 			}
 
 			groups := []*pipelineGroup{buildGroup, testGroup}
-			if err := expandArraySteps(groups); err != nil {
+			if _, err := expandArraySteps(groups); err != nil {
 				t.Fatalf("expandArraySteps() error: %v", err)
 			}
 

--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -121,9 +121,11 @@ func stepTags(step map[string]any) []string {
 func (c *converter) convertGroups(gs []*pipelineGroup, filter *stepFilter) (
 	[]*bkPipelineGroup, error,
 ) {
-	if err := expandArraySteps(gs); err != nil {
+	configs, err := expandArraySteps(gs)
+	if err != nil {
 		return nil, fmt.Errorf("expand array: %w", err)
 	}
+	filter.resolveArraySelects(configs)
 
 	set := newStepNodeSet()
 	var groupNodes []*stepNode

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -1164,6 +1164,115 @@ func TestConvertPipelineGroups(t *testing.T) {
 	}
 }
 
+func TestConvertPipelineGroups_ArraySelectWithDeps(t *testing.T) {
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{{
+			"label":    "Build {{array.python}}",
+			"key":      "build-step",
+			"commands": []any{"echo build"},
+			"array": map[string]any{
+				"python": []any{"3.10", "3.11", "3.12"},
+			},
+		}},
+	}, {
+		Group: "test",
+		Steps: []map[string]any{{
+			"label":      "Test py3.10",
+			"key":        "test-py310",
+			"commands":   []any{"echo test"},
+			"depends_on": "build-step--python310",
+		}},
+	}}
+
+	// Select the test step; dependency should pull in only
+	// build-step--python310, not the other variants.
+	filter, err := newStepFilter(
+		nil, []string{"test-py310"}, nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{"build-step--python310", "test-py310"}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
+func TestConvertPipelineGroups_BareArrayKeySelect(t *testing.T) {
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{{
+			"label":    "Build {{array.python}}",
+			"key":      "build-step",
+			"commands": []any{"echo build"},
+			"array": map[string]any{
+				"python": []any{"3.10", "3.11"},
+			},
+		}},
+	}, {
+		Group: "other",
+		Steps: []map[string]any{{
+			"label":    "Other",
+			"key":      "other-step",
+			"commands": []any{"echo other"},
+		}},
+	}}
+
+	// Bare "build-step" should expand to all variants, and
+	// "other-step" group should be excluded.
+	filter, err := newStepFilter(
+		nil, []string{"build-step"}, nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	if len(bk) != 1 {
+		t.Fatalf("got %d groups, want 1", len(bk))
+	}
+	if len(bk[0].Steps) != 2 {
+		t.Fatalf("got %d steps, want 2", len(bk[0].Steps))
+	}
+}
+
 func TestConvertPipelineGroups_ArrayBaseKeyDependencyExpansion(t *testing.T) {
 	// Verify that when a downstream step depends on the base key,
 	// the dependency is expanded to all expanded keys directly.

--- a/raycicmd/step_filter.go
+++ b/raycicmd/step_filter.go
@@ -23,6 +23,30 @@ type stepFilter struct {
 	noTagMeansAlways bool
 }
 
+func (f *stepFilter) hasSelects() bool {
+	return f.selects != nil || f.tagSelects != nil
+}
+
+// resolveArraySelects expands bare keys in selects that match array
+// base keys into all their variant keys.
+// Must be called after expandArraySteps populates the configs.
+func (f *stepFilter) resolveArraySelects(
+	configs map[string]*arrayConfig,
+) {
+	if f.selects == nil {
+		return
+	}
+	for key, cfg := range configs {
+		if !f.selects[key] {
+			continue
+		}
+		delete(f.selects, key)
+		for _, elem := range cfg.elements {
+			f.selects[elem.generateKey(key)] = true
+		}
+	}
+}
+
 func (f *stepFilter) reject(step *stepNode) bool {
 	return step.hasTagInMap(f.skipTags)
 }
@@ -59,7 +83,11 @@ func (f *stepFilter) hit(step *stepNode) bool {
 }
 
 func newStepFilter(
-	skipTags, selects []string, filterCmd []string, testRulesFiles []string, envs Envs, lister ChangeLister,
+	skipTags, selects []string,
+	filterCmd []string,
+	testRulesFiles []string,
+	envs Envs,
+	lister ChangeLister,
 ) (*stepFilter, error) {
 	var setup *filterSetup
 
@@ -110,7 +138,11 @@ type filterSetup struct {
 	tags   map[string]bool
 }
 
-func filterFromRuleFiles(testRulesFiles []string, envs Envs, lister ChangeLister) (*filterSetup, error) {
+func filterFromRuleFiles(
+	testRulesFiles []string,
+	envs Envs,
+	lister ChangeLister,
+) (*filterSetup, error) {
 	tags, err := RunTagAnalysis(testRulesFiles, envs, lister)
 	if err != nil {
 		return nil, err

--- a/raycicmd/step_filter_test.go
+++ b/raycicmd/step_filter_test.go
@@ -251,6 +251,102 @@ func TestStepFilter_selects(t *testing.T) {
 	}
 }
 
+func TestResolveArraySelects_bareKeyExpansion(t *testing.T) {
+	filter, err := newStepFilter(
+		nil,
+		[]string{"build", "non-array-step"},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	configs := map[string]*arrayConfig{
+		"build": {
+			dims: map[string][]string{"python": {"3.10", "3.11"}},
+			elements: []*arrayElement{
+				{values: map[string]string{"python": "3.10"}},
+				{values: map[string]string{"python": "3.11"}},
+			},
+		},
+	}
+
+	filter.resolveArraySelects(configs)
+
+	if !filter.selects["build--python310"] {
+		t.Errorf("build--python310 not in selects")
+	}
+	if !filter.selects["build--python311"] {
+		t.Errorf("build--python311 not in selects")
+	}
+	if filter.selects["build"] {
+		t.Errorf("bare key 'build' should have been removed")
+	}
+	if !filter.selects["non-array-step"] {
+		t.Errorf("non-array-step should remain in selects")
+	}
+}
+
+func TestResolveArraySelects_multipleArrayConfigs(t *testing.T) {
+	filter, err := newStepFilter(
+		nil,
+		[]string{"build-a", "build-b"},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	configs := map[string]*arrayConfig{
+		"build-a": {
+			dims: map[string][]string{"python": {"3.10"}},
+			elements: []*arrayElement{
+				{values: map[string]string{"python": "3.10"}},
+			},
+		},
+		"build-b": {
+			dims: map[string][]string{"cuda": {"12", "13"}},
+			elements: []*arrayElement{
+				{values: map[string]string{"cuda": "12"}},
+				{values: map[string]string{"cuda": "13"}},
+			},
+		},
+	}
+
+	filter.resolveArraySelects(configs)
+
+	want := map[string]bool{
+		"build-a--python310": true,
+		"build-b--cuda12":    true,
+		"build-b--cuda13":    true,
+	}
+	for k := range want {
+		if !filter.selects[k] {
+			t.Errorf("%s not in selects", k)
+		}
+	}
+	if filter.selects["build-a"] || filter.selects["build-b"] {
+		t.Errorf("bare keys should have been removed")
+	}
+	if len(filter.selects) != len(want) {
+		t.Errorf("selects has %d entries, want %d", len(filter.selects), len(want))
+	}
+}
+
+func TestResolveArraySelects_noSelects(t *testing.T) {
+	filter := &stepFilter{}
+	configs := map[string]*arrayConfig{
+		"build": {
+			dims:     map[string][]string{"python": {"3.10"}},
+			elements: []*arrayElement{{values: map[string]string{"python": "3.10"}}},
+		},
+	}
+	filter.resolveArraySelects(configs)
+	if filter.selects != nil {
+		t.Errorf("selects should remain nil")
+	}
+}
+
 func TestStepFilter_tagSelects(t *testing.T) {
 	filter, _ := newStepFilter(nil, []string{"tag:foo", "bar"}, nil, nil, nil, nil)
 	for _, node := range []*stepNode{


### PR DESCRIPTION
When RAYCI_SELECT contains a bare key that matches an array step's base key (e.g., RAYCI_SELECT=ray-core-build), expand it to all variant keys (ray-core-build--python310, ray-core-build--python311, etc.) so the select actually matches the expanded steps. Previously, bare base keys silently matched nothing because expanded step keys have --dimension suffixes.

Also changes expandArraySteps to return the configs map, making it available to callers for array-aware operations.

Topic: select-param-bare-key
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>