### PR TITLE
[rayci] Prune array variant group deps when RAYCI_SELECT is active

### DIFF
--- a/raycicmd/converter.go
+++ b/raycicmd/converter.go
@@ -118,6 +118,19 @@ func stepTags(step map[string]any) []string {
 	return nil
 }
 
+// arrayVariantKeySet builds a set of all expanded keys from array configs.
+func arrayVariantKeySet(
+	configs map[string]*arrayConfig,
+) map[string]struct{} {
+	keys := make(map[string]struct{})
+	for baseKey, cfg := range configs {
+		for _, elem := range cfg.elements {
+			keys[elem.generateKey(baseKey)] = struct{}{}
+		}
+	}
+	return keys
+}
+
 func (c *converter) convertGroups(gs []*pipelineGroup, filter *stepFilter) (
 	[]*bkPipelineGroup, error,
 ) {
@@ -158,6 +171,13 @@ func (c *converter) convertGroups(gs []*pipelineGroup, filter *stepFilter) (
 		return nil, fmt.Errorf("build index: %w", err)
 	}
 
+	// Build set of array variant keys for group dep pruning.
+	// Only computed when selects are active.
+	var arrayVariantKeys map[string]struct{}
+	if filter.hasSelects() {
+		arrayVariantKeys = arrayVariantKeySet(configs)
+	}
+
 	// Populate dependsOn.
 	for _, groupNode := range groupNodes {
 		// A group node is different from a step node.
@@ -171,6 +191,14 @@ func (c *converter) convertGroups(gs []*pipelineGroup, filter *stepFilter) (
 		groupDeps := make(map[string]struct{})
 		for _, dep := range groupNode.srcGroup.DependsOn {
 			if depNode, ok := set.byKey(dep); ok {
+				// When selects are active, skip group deps that
+				// are array variants. Steps must declare their
+				// own depends_on to pull in specific variants.
+				if len(arrayVariantKeys) > 0 {
+					if _, ok := arrayVariantKeys[depNode.key]; ok {
+						continue
+					}
+				}
 				groupDeps[depNode.id] = struct{}{}
 			}
 		}

--- a/raycicmd/converter_test.go
+++ b/raycicmd/converter_test.go
@@ -1273,6 +1273,333 @@ func TestConvertPipelineGroups_BareArrayKeySelect(t *testing.T) {
 	}
 }
 
+func TestConvertPipelineGroups_GroupDepPruning(t *testing.T) {
+	// When selects are active, array variant group deps should be pruned.
+	// Non-array group deps (like "forge") should be kept.
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{
+			{
+				"label":    "Build {{array.python}}",
+				"key":      "build-step",
+				"commands": []any{"echo build"},
+				"array": map[string]any{
+					"python": []any{"3.10", "3.11", "3.12"},
+				},
+			},
+			{
+				"label":    "Forge",
+				"key":      "forge",
+				"commands": []any{"echo forge"},
+			},
+		},
+	}, {
+		Group:     "tests",
+		DependsOn: []string{"forge", "build-step(*)"},
+		Steps: []map[string]any{{
+			"label":    "Test",
+			"key":      "test-step",
+			"commands": []any{"echo test"},
+		}},
+	}}
+
+	// Select only test-step. Without pruning, all 3 build-step
+	// variants would be pulled in via group deps. With pruning,
+	// only forge (non-array) is kept.
+	filter, err := newStepFilter(
+		nil, []string{"test-step"}, nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{"forge", "test-step"}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
+func TestConvertPipelineGroups_GroupDepNoPruningWithoutSelects(
+	t *testing.T,
+) {
+	// Without selects active, all group deps should be kept.
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{
+			{
+				"label":    "Build {{array.python}}",
+				"key":      "build-step",
+				"commands": []any{"echo build"},
+				"array": map[string]any{
+					"python": []any{"3.10", "3.11"},
+				},
+			},
+			{
+				"label":    "Forge",
+				"key":      "forge",
+				"commands": []any{"echo forge"},
+			},
+		},
+	}, {
+		Group:     "tests",
+		DependsOn: []string{"forge", "build-step(*)"},
+		Steps: []map[string]any{{
+			"label":    "Test",
+			"key":      "test-step",
+			"commands": []any{"echo test"},
+			"tags":     []any{"run-me"},
+		}},
+	}}
+
+	// No selects — filter by tag only. All group deps should be kept.
+	filter := &stepFilter{tags: stringSet("run-me")}
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{
+		"build-step--python310", "build-step--python311",
+		"forge", "test-step",
+	}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
+func TestConvertPipelineGroups_SelectWithExplicitArrayDep(
+	t *testing.T,
+) {
+	// When selects include a specific array variant, it should
+	// be included even though group dep pruning is active.
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{{
+			"label":    "Build {{array.python}}",
+			"key":      "build-step",
+			"commands": []any{"echo build"},
+			"array": map[string]any{
+				"python": []any{"3.10", "3.11", "3.12"},
+			},
+		}},
+	}, {
+		Group:     "tests",
+		DependsOn: []string{"build-step(*)"},
+		Steps: []map[string]any{{
+			"label":    "Test",
+			"key":      "test-step",
+			"commands": []any{"echo test"},
+		}},
+	}}
+
+	// Select test-step AND the specific build variant needed.
+	filter, err := newStepFilter(
+		nil,
+		[]string{"test-step", "build-step--python310"},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{"build-step--python310", "test-step"}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
+func TestConvertPipelineGroups_StepDepOverridesGroupDepPruning(
+	t *testing.T,
+) {
+	// When group deps are pruned, step-level depends_on should still
+	// pull in the specific array variant through dependency marking.
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{{
+			"label":    "Build {{array.python}}",
+			"key":      "build-step",
+			"commands": []any{"echo build"},
+			"array": map[string]any{
+				"python": []any{"3.10", "3.11", "3.12"},
+			},
+		}},
+	}, {
+		Group:     "tests",
+		DependsOn: []string{"build-step(*)"},
+		Steps: []map[string]any{{
+			"label":      "Test",
+			"key":        "test-step",
+			"commands":   []any{"echo test"},
+			"depends_on": "build-step--python310",
+		}},
+	}}
+
+	// Select only test-step. Group dep pruning removes all
+	// build-step variants from group deps. But the step-level
+	// depends_on on build-step--python310 should still include it.
+	filter, err := newStepFilter(
+		nil, []string{"test-step"}, nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{"build-step--python310", "test-step"}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
+func TestConvertPipelineGroups_TagSelectPrunesGroupDeps(
+	t *testing.T,
+) {
+	// Tag-only selects (RAYCI_SELECT=tag:foo) should also trigger
+	// group dep pruning of array variants.
+	const buildID = "abc123"
+	info := &buildInfo{buildID: buildID}
+
+	c := newConverter(&config{
+		CITemp:       "s3://ci-temp/",
+		RunnerQueues: map[string]string{"default": "runner"},
+	}, info)
+
+	groups := []*pipelineGroup{{
+		Group: "build",
+		Steps: []map[string]any{{
+			"label":    "Build {{array.python}}",
+			"key":      "build-step",
+			"commands": []any{"echo build"},
+			"array": map[string]any{
+				"python": []any{"3.10", "3.11"},
+			},
+		}},
+	}, {
+		Group:     "tests",
+		DependsOn: []string{"build-step(*)"},
+		Steps: []map[string]any{{
+			"label":    "Test",
+			"key":      "test-step",
+			"commands": []any{"echo test"},
+			"tags":     []any{"run-me"},
+		}},
+	}}
+
+	filter, err := newStepFilter(
+		nil, []string{"tag:run-me"}, nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newStepFilter: %v", err)
+	}
+	filter.runAll = true
+
+	bk, err := c.convertGroups(groups, filter)
+	if err != nil {
+		t.Fatalf("convertGroups: %v", err)
+	}
+
+	var allKeys []string
+	for _, g := range bk {
+		for _, s := range g.Steps {
+			step := s.(map[string]any)
+			if k, ok := step["key"]; ok {
+				allKeys = append(allKeys, k.(string))
+			}
+		}
+	}
+
+	wantKeys := []string{"test-step"}
+	if !reflect.DeepEqual(allKeys, wantKeys) {
+		t.Errorf("step keys = %v, want %v", allKeys, wantKeys)
+	}
+}
+
 func TestConvertPipelineGroups_ArrayBaseKeyDependencyExpansion(t *testing.T) {
 	// Verify that when a downstream step depends on the base key,
 	// the dependency is expanded to all expanded keys directly.


### PR DESCRIPTION
When RAYCI_SELECT is set, group-level depends_on entries that are array-expanded variants are skipped. This prevents selecting a single test step from pulling in all array build variants (e.g., all 5 ray-core-build python versions) through the group dependency fan-out.

Non-array group deps (like forge) are preserved. Steps that need specific array variants can either add them to RAYCI_SELECT directly or declare step-level depends_on.

Topic: select-param-prune-group-deps
Relative: select-param-bare-key
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>