### PR TITLE
fix(wanda): prioritize local Docker images before falling back to remote registry

### DIFF
--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -246,7 +246,7 @@ localSrc, localErr := resolveDockerImage(f.docker, from, from)
 		// Local image not found, try remote
 		src, err := resolveRemoteImage(from, from, f.remoteOpts...)
 		if err != nil {
-			return nil, fmt.Errorf("resolve remote image %s (local error: %v): %w", from, localErr, err)
+return nil, fmt.Errorf("resolve remote image %s: %w", from, err)
 		}
 		m[from] = src
 	}

--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -236,7 +236,7 @@ func (f *Forge) resolveBases(froms []string) (map[string]*imageSource, error) {
 
 		// A normal remote image that we need to pull from the network.
 		// Try local image first, fallback to remote if not found locally.
-		localSrc, localErr := resolveLocalImage(from, from)
+localSrc, localErr := resolveDockerImage(f.docker, from, from)
 		if localErr == nil {
 			log.Printf("using local image for %s", from)
 			m[from] = localSrc

--- a/wanda/forge.go
+++ b/wanda/forge.go
@@ -235,9 +235,18 @@ func (f *Forge) resolveBases(froms []string) (map[string]*imageSource, error) {
 		}
 
 		// A normal remote image that we need to pull from the network.
+		// Try local image first, fallback to remote if not found locally.
+		localSrc, localErr := resolveLocalImage(from, from)
+		if localErr == nil {
+			log.Printf("using local image for %s", from)
+			m[from] = localSrc
+			continue
+		}
+
+		// Local image not found, try remote
 		src, err := resolveRemoteImage(from, from, f.remoteOpts...)
 		if err != nil {
-			return nil, fmt.Errorf("resolve remote image %s: %w", from, err)
+			return nil, fmt.Errorf("resolve remote image %s (local error: %v): %w", from, localErr, err)
 		}
 		m[from] = src
 	}


### PR DESCRIPTION
Prioritize locally available Docker images when resolving base images, falling back to remote registry only if not found locally.