### PR TITLE
[raycicmd] Add prefix: token to RAYCI_SELECT for prefix matching

### DIFF
--- a/raycicmd/main.go
+++ b/raycicmd/main.go
@@ -53,7 +53,15 @@ func parseFlags(args []string) (*Flags, []string) {
 	)
 	set.StringVar(
 		&flags.Select, "select", "",
-		"Select specific step IDs or keys to run, separated by commas.",
+		"Select steps to run, separated by commas. Entry forms: "+
+			"<value> matches a step whose ID or key equals <value> exactly; "+
+			"prefix:<value> matches when <value> is a string prefix of the step ID or key; "+
+			"tag:<value> matches when the step has tag <value>. "+
+			"Selection also applies to group keys, so matching a group pulls in "+
+			"all of its sub-steps. "+
+			"prefix: and tag: are reserved, so a step keyed prefix:foo or tag:foo "+
+			"cannot be selected by a bare token. "+
+			"Defaults to the RAYCI_SELECT env var when empty.",
 	)
 	set.StringVar(
 		&flags.BuildkiteDir, "buildkite-dir", "",

--- a/raycicmd/step_filter.go
+++ b/raycicmd/step_filter.go
@@ -17,8 +17,9 @@ type stepFilter struct {
 	tags   map[string]bool
 
 	// third pass: selecting steps
-	selects    map[string]bool // based on ID or key
-	tagSelects map[string]bool // or based on tags
+	selects       map[string]bool // exact match on ID or key
+	tagSelects    map[string]bool // exact match on tag (tag:<name>)
+	prefixSelects map[string]bool // string prefix of ID or key (prefix:<name>)
 
 	noTagMeansAlways bool
 }
@@ -32,12 +33,14 @@ func (f *stepFilter) accept(step *stepNode) bool {
 }
 
 func (f *stepFilter) acceptSelectHit(step *stepNode) bool {
-	if f.selects == nil && f.tagSelects == nil {
+	if f.selects == nil && f.tagSelects == nil && f.prefixSelects == nil {
 		// no select filters, accept everything.
 		return true
 	}
 
-	return step.selectHit(f.selects) || step.hasTagInMap(f.tagSelects)
+	return step.selectHit(f.selects) ||
+		step.hasTagInMap(f.tagSelects) ||
+		step.prefixHit(f.prefixSelects)
 }
 
 func (f *stepFilter) acceptTagHit(step *stepNode) bool {
@@ -59,7 +62,11 @@ func (f *stepFilter) hit(step *stepNode) bool {
 }
 
 func newStepFilter(
-	skipTags, selects []string, filterCmd []string, testRulesFiles []string, envs Envs, lister ChangeLister,
+	skipTags, selects []string,
+	filterCmd []string,
+	testRulesFiles []string,
+	envs Envs,
+	lister ChangeLister,
 ) (*stepFilter, error) {
 	var setup *filterSetup
 
@@ -91,12 +98,18 @@ func newStepFilter(
 	if selects != nil {
 		filter.selects = make(map[string]bool)
 		filter.tagSelects = make(map[string]bool)
+		filter.prefixSelects = make(map[string]bool)
 
 		for _, k := range selects {
-			if strings.HasPrefix(k, "tag:") {
-				name := strings.TrimPrefix(k, "tag:")
-				filter.tagSelects[name] = true
-			} else {
+			switch {
+			case strings.HasPrefix(k, "tag:"):
+				filter.tagSelects[strings.TrimPrefix(k, "tag:")] = true
+			case strings.HasPrefix(k, "prefix:"):
+				p := strings.TrimPrefix(k, "prefix:")
+				if p != "" {
+					filter.prefixSelects[p] = true
+				}
+			default:
 				filter.selects[k] = true
 			}
 		}
@@ -110,7 +123,11 @@ type filterSetup struct {
 	tags   map[string]bool
 }
 
-func filterFromRuleFiles(testRulesFiles []string, envs Envs, lister ChangeLister) (*filterSetup, error) {
+func filterFromRuleFiles(
+	testRulesFiles []string,
+	envs Envs,
+	lister ChangeLister,
+) (*filterSetup, error) {
 	tags, err := RunTagAnalysis(testRulesFiles, envs, lister)
 	if err != nil {
 		return nil, err

--- a/raycicmd/step_filter.go
+++ b/raycicmd/step_filter.go
@@ -103,10 +103,11 @@ func newStepFilter(
 		for _, k := range selects {
 			switch {
 			case strings.HasPrefix(k, "tag:"):
-				filter.tagSelects[strings.TrimPrefix(k, "tag:")] = true
+				if t := strings.TrimPrefix(k, "tag:"); t != "" {
+					filter.tagSelects[t] = true
+				}
 			case strings.HasPrefix(k, "prefix:"):
-				p := strings.TrimPrefix(k, "prefix:")
-				if p != "" {
+				if p := strings.TrimPrefix(k, "prefix:"); p != "" {
 					filter.prefixSelects[p] = true
 				}
 			default:

--- a/raycicmd/step_filter_test.go
+++ b/raycicmd/step_filter_test.go
@@ -318,16 +318,18 @@ func TestStepFilter_prefixSelects(t *testing.T) {
 		}
 	}
 
-	// `prefix:` with nothing after the colon is dropped at parse time so
-	// it never matches everything.
-	filter, _ = newStepFilter(nil, []string{"prefix:"}, nil, nil, nil, nil)
-	for _, node := range []*stepNode{
-		{key: "anything"},
-		{id: "anything"},
-		{id: "anything", tags: []string{"x"}},
-	} {
-		if filter.accept(node) {
-			t.Errorf("empty prefix should not match %+v", node)
+	// `prefix:` and `tag:` with nothing after the colon are dropped at
+	// parse time so they never match everything.
+	for _, token := range []string{"prefix:", "tag:"} {
+		filter, _ := newStepFilter(nil, []string{token}, nil, nil, nil, nil)
+		for _, node := range []*stepNode{
+			{key: "anything"},
+			{id: "anything"},
+			{id: "anything", tags: []string{"x"}},
+		} {
+			if filter.accept(node) {
+				t.Errorf("empty %q should not match %+v", token, node)
+			}
 		}
 	}
 }

--- a/raycicmd/step_filter_test.go
+++ b/raycicmd/step_filter_test.go
@@ -249,6 +249,87 @@ func TestStepFilter_selects(t *testing.T) {
 			t.Errorf("hit %+v", node)
 		}
 	}
+
+	// Bare tokens stay exact-match: "upload-rayturbo" must not match
+	// keys like "upload-rayturbo-staging" or "upload-rayturbo-prod".
+	filter, _ = newStepFilter(nil, []string{"upload-rayturbo"}, nil, nil, nil, nil)
+	for _, node := range []*stepNode{
+		{key: "upload-rayturbo"},
+		{id: "upload-rayturbo"},
+	} {
+		if !filter.accept(node) {
+			t.Errorf("exact select miss %+v", node)
+		}
+	}
+	for _, node := range []*stepNode{
+		{key: "upload-rayturbo-staging"},
+		{id: "upload-rayturbo-prod"},
+	} {
+		if filter.accept(node) {
+			t.Errorf("exact select should not match a prefix: %+v", node)
+		}
+	}
+}
+
+func TestStepFilter_prefixSelects(t *testing.T) {
+	// `prefix:` tokens hit when the value is a string prefix of either
+	// stepNode.id or stepNode.key. They are independent from bare tokens
+	// (exact match) and tag: tokens (exact tag match).
+	filter, _ := newStepFilter(
+		nil,
+		[]string{"prefix:upload-rayturbo", "exact-key", "tag:enabled"},
+		nil, nil, nil, nil,
+	)
+	for _, node := range []*stepNode{
+		// prefix hits on key.
+		{key: "upload-rayturbo-staging"},
+		{key: "upload-rayturbo-prod"},
+		{key: "upload-rayturbo"}, // prefix is reflexive: equal also hits.
+		// prefix hits on id.
+		{id: "upload-rayturbo-extra"},
+		// id wins via the bare exact path even when key would not match.
+		{id: "exact-key", key: "something-else"},
+		// exact key hit via the bare path even when prefix would not match.
+		{key: "exact-key"},
+		// tag hit via tag: path.
+		{id: "anything", tags: []string{"enabled"}},
+		// All three paths satisfied at once. Documents that OR semantics
+		// admit multiple-path hits; the single-path positive cases above
+		// are what guard against a || -> && regression.
+		{
+			id:   "exact-key",
+			key:  "upload-rayturbo-staging",
+			tags: []string{"enabled"},
+		},
+	} {
+		if !filter.accept(node) {
+			t.Errorf("miss %+v", node)
+		}
+	}
+	for _, node := range []*stepNode{
+		{key: "upload"},                           // key shorter than the prefix.
+		{key: "rayturbo-upload"},                  // prefix is not a leading substring of key.
+		{id: "rayturbo-upload"},                   // prefix is not a leading substring of id.
+		{id: "ex"},                                // bare select requires exact match.
+		{id: "anything", tags: []string{"other"}}, // tag mismatch.
+	} {
+		if filter.accept(node) {
+			t.Errorf("unexpected hit %+v", node)
+		}
+	}
+
+	// `prefix:` with nothing after the colon is dropped at parse time so
+	// it never matches everything.
+	filter, _ = newStepFilter(nil, []string{"prefix:"}, nil, nil, nil, nil)
+	for _, node := range []*stepNode{
+		{key: "anything"},
+		{id: "anything"},
+		{id: "anything", tags: []string{"x"}},
+	} {
+		if filter.accept(node) {
+			t.Errorf("empty prefix should not match %+v", node)
+		}
+	}
 }
 
 func TestStepFilter_tagSelects(t *testing.T) {

--- a/raycicmd/step_node.go
+++ b/raycicmd/step_node.go
@@ -3,6 +3,7 @@ package raycicmd
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 func intersects(set1, set2 []string) bool {
@@ -109,6 +110,23 @@ func (n *stepNode) selectHit(selects map[string]bool) bool {
 	}
 	if n.key != "" {
 		if _, ok := selects[n.key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// prefixHit ignores empty entries in prefixes; newStepFilter also drops
+// them at parse time, so this is a defense-in-depth guard.
+func (n *stepNode) prefixHit(prefixes map[string]bool) bool {
+	for p := range prefixes {
+		if p == "" {
+			continue
+		}
+		if n.id != "" && strings.HasPrefix(n.id, p) {
+			return true
+		}
+		if n.key != "" && strings.HasPrefix(n.key, p) {
 			return true
 		}
 	}

--- a/raycicmd/step_node_test.go
+++ b/raycicmd/step_node_test.go
@@ -165,6 +165,10 @@ func TestStepNodeSelectHit(t *testing.T) {
 		{selects: set("step-id", "step-key"), want: true},
 		{selects: set("step-id", "step-key", "other"), want: true},
 		{selects: set("other"), want: false},
+
+		// selectHit is exact match only; prefixes do not hit.
+		{selects: set("step-"), want: false},
+		{selects: set("s"), want: false},
 	} {
 		if got := n.selectHit(test.selects); got != test.want {
 			t.Errorf(
@@ -193,5 +197,63 @@ func TestStepNodeSelectHit(t *testing.T) {
 				test.selects, got, test.want,
 			)
 		}
+	}
+}
+
+func TestStepNodePrefixHit(t *testing.T) {
+	set := func(prefixes ...string) map[string]bool {
+		m := make(map[string]bool)
+		for _, p := range prefixes {
+			m[p] = true
+		}
+		return m
+	}
+
+	n := &stepNode{id: "step-id", key: "step-key"}
+	for _, test := range []struct {
+		prefixes map[string]bool
+		want     bool
+	}{
+		// exact strings still hit (a string is a prefix of itself).
+		{prefixes: set("step-id"), want: true},
+		{prefixes: set("step-key"), want: true},
+
+		// proper prefixes of id or key hit.
+		{prefixes: set("step-"), want: true},
+		{prefixes: set("s"), want: true},
+
+		// longer than both id and key: no hit.
+		{prefixes: set("step-key-extra"), want: false},
+
+		// not a prefix of id or key.
+		{prefixes: set("tep"), want: false},
+
+		// empty prefix is ignored: never hits.
+		{prefixes: set(""), want: false},
+
+		// at least one of multiple entries hits.
+		{prefixes: set("nope", "step-"), want: true},
+	} {
+		if got := n.prefixHit(test.prefixes); got != test.want {
+			t.Errorf(
+				"prefixHit %+v: got %v, want %v",
+				test.prefixes, got, test.want,
+			)
+		}
+	}
+
+	// id-only node: prefix on id hits.
+	if !(&stepNode{id: "step-id"}).prefixHit(set("step-")) {
+		t.Errorf("prefixHit on id-only node: want hit")
+	}
+
+	// key-only node: prefix on key hits.
+	if !(&stepNode{key: "step-key"}).prefixHit(set("step-")) {
+		t.Errorf("prefixHit on key-only node: want hit")
+	}
+
+	// empty node never hits.
+	if (&stepNode{}).prefixHit(set("step-")) {
+		t.Errorf("prefixHit on empty node: want miss")
 	}
 }

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -18,15 +18,15 @@ TMP_DIR="$(mktemp -d)"
 
 RAYCI_BRANCH="select-prefix-token"
 
-echo "--- Install rayci"
+echo "--- Build rayci locally"
 
 readonly GO_VERSION=1.24.5
 curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
 export GOROOT="$TMP_DIR/go"
 export GOPATH="$TMP_DIR/gopath"
 export GOPRIVATE="github.com/ray-project/rayci"
-"$TMP_DIR/go/bin/go" install 'github.com/ray-project/rayci@'"${RAYCI_BRANCH}"
+"$TMP_DIR/go/bin/go" build -o "$TMP_DIR/rayci" .
 
 echo "--- Run rayci"
 
-exec "$GOPATH/bin/rayci" "$@"
+exec "$TMP_DIR/rayci" "$@"

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -4,19 +4,19 @@ set -euo pipefail
 
 TMP_DIR="$(mktemp -d)"
 
-if [[ -f .rayciversion ]]; then
-  RAYCI_VERSION="$(cat .rayciversion)"
-  echo "--- Install rayci binary ${RAYCI_VERSION}"
-  curl -sfL "https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/rayci-linux-amd64" -o "$TMP_DIR/rayci"
-  chmod +x "$TMP_DIR/rayci"
-  exec "$TMP_DIR/rayci" "$@"
+# if [[ -f .rayciversion ]]; then
+#   RAYCI_VERSION="$(cat .rayciversion)"
+#   echo "--- Install rayci binary ${RAYCI_VERSION}"
+#   curl -sfL "https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/rayci-linux-amd64" -o "$TMP_DIR/rayci"
+#   chmod +x "$TMP_DIR/rayci"
+#   exec "$TMP_DIR/rayci" "$@"
 
-  exit 1  # Unreachable; just for safe-guarding.
-fi
+#   exit 1  # Unreachable; just for safe-guarding.
+# fi
 
 # Legacy path; build from source.
 
-RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
+RAYCI_BRANCH="select-prefix-token"
 
 echo "--- Install rayci"
 

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -4,19 +4,19 @@ set -euo pipefail
 
 TMP_DIR="$(mktemp -d)"
 
-# if [[ -f .rayciversion ]]; then
-#   RAYCI_VERSION="$(cat .rayciversion)"
-#   echo "--- Install rayci binary ${RAYCI_VERSION}"
-#   curl -sfL "https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/rayci-linux-amd64" -o "$TMP_DIR/rayci"
-#   chmod +x "$TMP_DIR/rayci"
-#   exec "$TMP_DIR/rayci" "$@"
+if [[ -f .rayciversion ]]; then
+  RAYCI_VERSION="$(cat .rayciversion)"
+  echo "--- Install rayci binary ${RAYCI_VERSION}"
+  curl -sfL "https://github.com/ray-project/rayci/releases/download/v${RAYCI_VERSION}/rayci-linux-amd64" -o "$TMP_DIR/rayci"
+  chmod +x "$TMP_DIR/rayci"
+  exec "$TMP_DIR/rayci" "$@"
 
-#   exit 1  # Unreachable; just for safe-guarding.
-# fi
+  exit 1  # Unreachable; just for safe-guarding.
+fi
 
 # Legacy path; build from source.
 
-RAYCI_BRANCH="select-prefix-token"
+RAYCI_BRANCH="${RAYCI_BRANCH:-stable}"
 
 echo "--- Install rayci"
 

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -16,17 +16,25 @@ TMP_DIR="$(mktemp -d)"
 
 # Legacy path; build from source.
 
-RAYCI_BRANCH="select-prefix-token"
+if [ ! -f "/tmp/rayci" ]; then
+  RAYCI_BRANCH="select-prefix-token"
 
-echo "--- Build rayci locally"
+  echo "--- Build rayci locally"
 
-readonly GO_VERSION=1.24.5
-curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
-export GOROOT="$TMP_DIR/go"
-export GOPATH="$TMP_DIR/gopath"
-export GOPRIVATE="github.com/ray-project/rayci"
-"$TMP_DIR/go/bin/go" build -o "$TMP_DIR/rayci" .
+  git clone https://github.com/ray-project/rayci.git -b "$RAYCI_BRANCH" "$TMP_DIR/rayci-repo"
+  cd "$TMP_DIR/rayci-repo"
+
+  readonly GO_VERSION=1.24.5
+  curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
+  export GOROOT="$TMP_DIR/go"
+  export GOPATH="$TMP_DIR/gopath"
+  export GOPRIVATE="github.com/ray-project/rayci"
+  "$TMP_DIR/go/bin/go" build -o "/tmp/rayci" .
+  chmod +x /tmp/rayci
+
+  cd -
+fi
 
 echo "--- Run rayci"
 
-exec "$TMP_DIR/rayci" "$@"
+exec "/tmp/rayci" "$@"

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -16,25 +16,17 @@ TMP_DIR="$(mktemp -d)"
 
 # Legacy path; build from source.
 
-if [ ! -f "/tmp/rayci" ]; then
-  RAYCI_BRANCH="select-prefix-token"
+RAYCI_BRANCH="select-prefix-token"
 
-  echo "--- Build rayci locally"
+echo "--- Build rayci locally"
 
-  git clone https://github.com/ray-project/rayci.git -b "$RAYCI_BRANCH" "$TMP_DIR/rayci-repo"
-  cd "$TMP_DIR/rayci-repo"
-
-  readonly GO_VERSION=1.24.5
-  curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
-  export GOROOT="$TMP_DIR/go"
-  export GOPATH="$TMP_DIR/gopath"
-  export GOPRIVATE="github.com/ray-project/rayci"
-  "$TMP_DIR/go/bin/go" build -o "/tmp/rayci" .
-  chmod +x /tmp/rayci
-
-  cd -
-fi
+readonly GO_VERSION=1.24.5
+curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
+export GOROOT="$TMP_DIR/go"
+export GOPATH="$TMP_DIR/gopath"
+export GOPRIVATE="github.com/ray-project/rayci"
+"$TMP_DIR/go/bin/go" build -o "$TMP_DIR/rayci" .
 
 echo "--- Run rayci"
 
-exec "/tmp/rayci" "$@"
+exec "$TMP_DIR/rayci" "$@"

--- a/run_rayci.sh
+++ b/run_rayci.sh
@@ -18,15 +18,15 @@ TMP_DIR="$(mktemp -d)"
 
 RAYCI_BRANCH="select-prefix-token"
 
-echo "--- Build rayci locally"
+echo "--- Install rayci"
 
 readonly GO_VERSION=1.24.5
 curl -sfL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xzf - -C "$TMP_DIR"
 export GOROOT="$TMP_DIR/go"
 export GOPATH="$TMP_DIR/gopath"
 export GOPRIVATE="github.com/ray-project/rayci"
-"$TMP_DIR/go/bin/go" build -o "$TMP_DIR/rayci" .
+"$TMP_DIR/go/bin/go" install 'github.com/ray-project/rayci@'"${RAYCI_BRANCH}"
 
 echo "--- Run rayci"
 
-exec "$TMP_DIR/rayci" "$@"
+exec "$GOPATH/bin/rayci" "$@"


### PR DESCRIPTION
## Summary
- Add a `prefix:<value>` token to `-select` and `RAYCI_SELECT` that hits a step when `<value>` is a string prefix of the step's id or key, letting one entry pick a family of related step keys.
- Bare tokens remain exact-match against id or key (back-compat); `tag:<value>` is unchanged.
- Empty `prefix:` value is dropped at parse time and filtered defensively in the consumer (`prefixHit`).
- `-select` help text enumerates the three forms, notes that group keys are also matched (pulling in sub-steps), and that `prefix:`/`tag:` are reserved namespaces.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go fmt ./...`
- [x] New unit tests `TestStepNodePrefixHit` and `TestStepFilter_prefixSelects` cover prefix-on-id, prefix-on-key, reflexive equality, longer-than-key, non-prefix, empty-prefix at parse time and at consumer, OR composition with bare/tag/prefix paths, and a paired prefix-on-id miss.
- [x] Existing `TestStepNodeSelectHit` and `TestStepFilter_selects` extended to lock in that bare tokens stay exact-match.
- [x] Manual smoke test: invoke `rayci -select prefix:<known-prefix>` against a sample pipeline and confirm only steps with matching id/key prefixes are emitted. : https://buildkite.com/ray-project/release-tests/builds/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)