### PR TITLE
[rayapp] updating rayapp to handle errors correctly

### DIFF
--- a/rayapp/anyscale_cli.go
+++ b/rayapp/anyscale_cli.go
@@ -57,15 +57,22 @@ func (ac *AnyscaleCLI) runAnyscaleCLI(args []string) (string, error) {
 
 	err := cmd.Run()
 	stdout := stdoutBuf.String()
+	stderr := stderrBuf.String()
 	if err != nil {
-		stderr := stderrBuf.String()
 		return "", fmt.Errorf(
 			"anyscale error: %w\nstdout: %s\nstderr: %s",
 			err, stdout, stderr,
 		)
 	}
-	if strings.Contains(stdout, "exec failed with exit code") {
-		return "", fmt.Errorf("anyscale error: command failed: %s", stdout)
+	// The anyscale CLI sometimes exits 0 even when a remote `run_command`
+	// failed, logging `exec failed with exit code N` via logrus (stderr).
+	// Scan both streams so we don't miss it.
+	if strings.Contains(stdout, "exec failed with exit code") ||
+		strings.Contains(stderr, "exec failed with exit code") {
+		return "", fmt.Errorf(
+			"anyscale error: command failed:\nstdout: %s\nstderr: %s",
+			stdout, stderr,
+		)
 	}
 
 	return stdout, nil

--- a/rayapp/anyscale_cli_test.go
+++ b/rayapp/anyscale_cli_test.go
@@ -118,9 +118,16 @@ func TestRunAnyscaleCLI(t *testing.T) {
 			wantErrStr: "stdout: useful context",
 		},
 		{
-			name:       "exec failed with exit code in output",
+			name:       "exec failed with exit code in stdout",
 			script:     "#!/bin/sh\necho \"exec failed with exit code 1\"; exit 0",
 			args:       []string{"deploy"},
+			wantErrStr: "anyscale error: command failed:",
+		},
+		{
+			name: "exec failed with exit code in stderr",
+			script: "#!/bin/sh\necho 'time=\"2026-05-04T19:45:34Z\" " +
+				"level=fatal msg=\"exec failed with exit code 1\"' >&2; exit 0",
+			args:       []string{"workspace_v2", "run_command"},
 			wantErrStr: "anyscale error: command failed:",
 		},
 	}


### PR DESCRIPTION
## Problem
The anyscale CLI sometimes exits with code 0 even when a remote `run_command`
has failed. In those cases it logs the failure via logrus to **stderr**, e.g.:

```
time="2026-05-04T19:45:34Z" level=fatal msg="exec failed with exit code 1"
```

Previously, `runAnyscaleCLI` in `rayapp/anyscale_cli.go` only scanned **stdout**
for the `exec failed with exit code` marker when the exit code was 0, so these
failures were silently treated as success. (Non-zero exits were already handled
and did include stderr in the error message — the gap was specifically the
exit-0-with-stderr-marker case.)

## Changes

### `rayapp/anyscale_cli.go`
- Capture `stderr` into a local variable unconditionally (alongside `stdout`)
  after `cmd.Run()`.
- Extend the post-success check to scan **both** `stdout` and `stderr` for
  `"exec failed with exit code"`.
- When that marker is found, include both streams in the returned error
  for full diagnostic context.

### `rayapp/anyscale_cli_test.go`
- Rename the existing stdout-marker case to `"exec failed with exit code in stdout"`.
- Add a new case `"exec failed with exit code in stderr"` that simulates the
  logrus-style stderr output (`level=fatal msg="exec failed with exit code 1"`)
  with exit code 0, and asserts the error is still surfaced.


Uncaught failure: https://buildkite.com/anyscale/template-probe/builds/42/canvas?jid=019e1cb4-1046-4ee7-a113-790ea651edbf&tab=output#019e1cb4-1046-4ee7-a113-790ea651edbf/L712