### PR TITLE
[rayapp] switch workspace ops from `--name` to `--id`

### DIFF
--- a/rayapp/anyscale_cli.go
+++ b/rayapp/anyscale_cli.go
@@ -40,11 +40,29 @@ func (ac *AnyscaleCLI) setRunFunc(f func(args []string) (string, error)) {
 // stdout and stderr for full diagnostic context.
 // Both streams are always displayed to the terminal.
 func (ac *AnyscaleCLI) runAnyscaleCLI(args []string) (string, error) {
+	stdout, _, err := ac.execAnyscale(args)
+	return stdout, err
+}
+
+// runAnyscaleCLICombined runs the anyscale CLI and returns stdout and stderr
+// merged into one string. Use this when you need to read CLI status messages
+// (e.g. "Workspace created successfully id: ...") that the CLI writes to
+// stderr.
+func (ac *AnyscaleCLI) runAnyscaleCLICombined(args []string) (string, error) {
+	stdout, stderr, err := ac.execAnyscale(args)
+	if err != nil {
+		return "", err
+	}
+	return stdout + stderr, nil
+}
+
+func (ac *AnyscaleCLI) execAnyscale(args []string) (string, string, error) {
 	if ac.runFunc != nil {
-		return ac.runFunc(args)
+		out, err := ac.runFunc(args)
+		return out, "", err
 	}
 	if !ac.isAnyscaleInstalled() {
-		return "", errors.New("anyscale is not installed")
+		return "", "", errors.New("anyscale is not installed")
 	}
 
 	fmt.Fprintf(os.Stdout, ">>> anyscale %s\n", strings.Join(args, " "))
@@ -59,7 +77,7 @@ func (ac *AnyscaleCLI) runAnyscaleCLI(args []string) (string, error) {
 	stdout := stdoutBuf.String()
 	stderr := stderrBuf.String()
 	if err != nil {
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"anyscale error: %w\nstdout: %s\nstderr: %s",
 			err, stdout, stderr,
 		)
@@ -69,11 +87,11 @@ func (ac *AnyscaleCLI) runAnyscaleCLI(args []string) (string, error) {
 	// Scan both streams so we don't miss it.
 	if strings.Contains(stdout, "exec failed with exit code") ||
 		strings.Contains(stderr, "exec failed with exit code") {
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"anyscale error: command failed:\nstdout: %s\nstderr: %s",
 			stdout, stderr,
 		)
 	}
 
-	return stdout, nil
+	return stdout, stderr, nil
 }

--- a/rayapp/anyscale_cli_fake_test.go
+++ b/rayapp/anyscale_cli_fake_test.go
@@ -138,6 +138,10 @@ func parseName(opts []string) string {
 	return parseFlag(opts, "--name", "-n")
 }
 
+func parseWorkspaceID(opts []string) string {
+	return parseFlag(opts, "--id", "--workspace-id")
+}
+
 func (f *fakeAnyscale) workspaceCreate(opts []string) (string, error) {
 	name := parseName(opts)
 	id := fmt.Sprintf("expwrk_%s", name)
@@ -148,9 +152,9 @@ func (f *fakeAnyscale) workspaceCreate(opts []string) (string, error) {
 }
 
 func (f *fakeAnyscale) workspaceGet(opts []string) (string, error) {
-	name := parseName(opts)
+	id := parseWorkspaceID(opts)
 	for _, ws := range f.workspaces {
-		if ws.Name == name {
+		if ws.ID == id {
 			m := map[string]any{
 				"id":    ws.ID,
 				"name":  ws.Name,
@@ -163,49 +167,49 @@ func (f *fakeAnyscale) workspaceGet(opts []string) (string, error) {
 			return string(bs), nil
 		}
 	}
-	return "", fmt.Errorf("fake: workspace not found: %s", name)
+	return "", fmt.Errorf("fake: workspace not found: %s", id)
 }
 
 func (f *fakeAnyscale) workspaceTerminate(opts []string) (string, error) {
-	name := parseName(opts)
-	return fmt.Sprintf("Terminating workspace '%s'", name), nil
+	id := parseWorkspaceID(opts)
+	return fmt.Sprintf("Terminating workspace '%s'", id), nil
 }
 
 func (f *fakeAnyscale) workspacePush(opts []string) (string, error) {
-	name := parseName(opts)
+	id := parseWorkspaceID(opts)
 	localDir := parseFlag(opts, "--local-dir")
-	return fmt.Sprintf("Sending %s to workspace '%s'", localDir, name), nil
+	return fmt.Sprintf("Sending %s to workspace '%s'", localDir, id), nil
 }
 
 func (f *fakeAnyscale) workspaceRunCommand(opts []string) (string, error) {
-	name := parseName(opts)
-	return fmt.Sprintf("Running command in workspace '%s'", name), nil
+	id := parseWorkspaceID(opts)
+	return fmt.Sprintf("Running command in workspace '%s'", id), nil
 }
 
 func (f *fakeAnyscale) workspaceStart(opts []string) (string, error) {
-	name := parseName(opts)
-	return fmt.Sprintf("Starting workspace '%s'", name), nil
+	id := parseWorkspaceID(opts)
+	return fmt.Sprintf("Starting workspace '%s'", id), nil
 }
 
 func (f *fakeAnyscale) workspaceStatus(opts []string) (string, error) {
-	name := parseName(opts)
+	id := parseWorkspaceID(opts)
 	for _, ws := range f.workspaces {
-		if ws.Name == name {
+		if ws.ID == id {
 			return ws.State, nil
 		}
 	}
-	return "", fmt.Errorf("fake: workspace not found: %s", name)
+	return "", fmt.Errorf("fake: workspace not found: %s", id)
 }
 
 func (f *fakeAnyscale) workspaceWait(opts []string) (string, error) {
-	name := parseName(opts)
+	id := parseWorkspaceID(opts)
 	state := parseFlag(opts, "--state")
 	return strings.Join([]string{
 		fmt.Sprintf(
 			"Waiting for workspace '%s' to reach target state %s, currently in state: %s",
-			name, state, state,
+			id, state, state,
 		),
-		fmt.Sprintf("Workspace '%s' reached target state, exiting", name),
+		fmt.Sprintf("Workspace '%s' reached target state, exiting", id),
 	}, "\n"), nil
 }
 

--- a/rayapp/anyscale_cli_workspace_v2.go
+++ b/rayapp/anyscale_cli_workspace_v2.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 )
 
 // WorkspaceState represents the state of an Anyscale workspace.
@@ -29,9 +30,21 @@ func (ws WorkspaceState) String() string {
 	return fmt.Sprintf("UNKNOWN(%d)", int(ws))
 }
 
-func (ac *AnyscaleCLI) createEmptyWorkspace(c *WorkspaceTestConfig) error {
+// workspaceCreatedIDRe matches the "Workspace created successfully id: ..."
+// status line that `anyscale workspace_v2 create` prints to stderr.
+var workspaceCreatedIDRe = regexp.MustCompile(
+	`Workspace created successfully id:\s+(expwrk_[A-Za-z0-9_-]+)`,
+)
+
+// createEmptyWorkspace creates a workspace and returns its id.
+//
+// The id is parsed from the CLI status line because every other workspace_v2
+// subcommand needs to address the workspace by --id rather than --name:
+// the by-name path on the Anyscale API has been observed to fail to find
+// newly-created workspaces, while the by-id path is reliable.
+func (ac *AnyscaleCLI) createEmptyWorkspace(c *WorkspaceTestConfig) (string, error) {
 	if c.template == nil {
-		return fmt.Errorf("template is required")
+		return "", fmt.Errorf("template is required")
 	}
 	args := []string{"workspace_v2", "create"}
 	args = append(args, "--name", c.workspaceName)
@@ -51,7 +64,7 @@ func (ac *AnyscaleCLI) createEmptyWorkspace(c *WorkspaceTestConfig) error {
 				c.template.ClusterEnv,
 			)
 			if err != nil {
-				return fmt.Errorf("cluster env: %w", err)
+				return "", fmt.Errorf("cluster env: %w", err)
 			}
 			args = append(args, "--image-uri", imageURI)
 			// Nightly images don't need --ray-version; the version
@@ -66,29 +79,22 @@ func (ac *AnyscaleCLI) createEmptyWorkspace(c *WorkspaceTestConfig) error {
 		args = append(args, "--compute-config", c.computeConfig)
 	}
 
-	_, err := ac.runAnyscaleCLI(args)
+	out, err := ac.runAnyscaleCLICombined(args)
 	if err != nil {
-		return fmt.Errorf("create empty workspace failed: %w", err)
+		return "", fmt.Errorf("create empty workspace failed: %w", err)
 	}
-
-	return nil
+	m := workspaceCreatedIDRe.FindStringSubmatch(out)
+	if len(m) != 2 {
+		return "", fmt.Errorf(
+			"create empty workspace: could not parse workspace id from output",
+		)
+	}
+	return m[1], nil
 }
 
-func (ac *AnyscaleCLI) getWorkspaceID(workspaceName string) (string, error) {
-	workspaceDescription, err := ac.getWorkspaceDescription(workspaceName)
-	if err != nil {
-		return "", fmt.Errorf("get workspace description failed: %w", err)
-	}
-	workspaceID, ok := workspaceDescription["id"].(string)
-	if !ok {
-		return "", fmt.Errorf("workspace ID not found in description")
-	}
-	return workspaceID, nil
-}
-
-func (ac *AnyscaleCLI) getWorkspaceDescription(workspaceName string) (map[string]any, error) {
+func (ac *AnyscaleCLI) getWorkspaceDescription(workspaceID string) (map[string]any, error) {
 	output, err := ac.runAnyscaleCLI(
-		[]string{"workspace_v2", "get", "--name", workspaceName, "--json"},
+		[]string{"workspace_v2", "get", "--id", workspaceID, "--json"},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get workspace failed: %w", err)
@@ -100,17 +106,17 @@ func (ac *AnyscaleCLI) getWorkspaceDescription(workspaceName string) (map[string
 	return workspaceDescription, nil
 }
 
-func (ac *AnyscaleCLI) terminateWorkspace(workspaceName string) error {
-	_, err := ac.runAnyscaleCLI([]string{"workspace_v2", "terminate", "--name", workspaceName})
+func (ac *AnyscaleCLI) terminateWorkspace(workspaceID string) error {
+	_, err := ac.runAnyscaleCLI([]string{"workspace_v2", "terminate", "--id", workspaceID})
 	if err != nil {
 		return fmt.Errorf("terminate workspace failed: %w", err)
 	}
 	return nil
 }
 
-func (ac *AnyscaleCLI) pushFolderToWorkspace(workspaceName, localFilePath string) error {
+func (ac *AnyscaleCLI) pushFolderToWorkspace(workspaceID, localFilePath string) error {
 	_, err := ac.runAnyscaleCLI(
-		[]string{"workspace_v2", "push", "--name", workspaceName, "--local-dir", localFilePath},
+		[]string{"workspace_v2", "push", "--id", workspaceID, "--local-dir", localFilePath},
 	)
 	if err != nil {
 		return fmt.Errorf("push file to workspace failed: %w", err)
@@ -118,9 +124,9 @@ func (ac *AnyscaleCLI) pushFolderToWorkspace(workspaceName, localFilePath string
 	return nil
 }
 
-func (ac *AnyscaleCLI) runCmdInWorkspace(workspaceName string, cmd string) error {
+func (ac *AnyscaleCLI) runCmdInWorkspace(workspaceID string, cmd string) error {
 	_, err := ac.runAnyscaleCLI(
-		[]string{"workspace_v2", "run_command", "--name", workspaceName, cmd},
+		[]string{"workspace_v2", "run_command", "--id", workspaceID, cmd},
 	)
 	if err != nil {
 		return fmt.Errorf("run command in workspace failed: %w", err)
@@ -128,16 +134,16 @@ func (ac *AnyscaleCLI) runCmdInWorkspace(workspaceName string, cmd string) error
 	return nil
 }
 
-func (ac *AnyscaleCLI) startWorkspace(workspaceName string) error {
-	_, err := ac.runAnyscaleCLI([]string{"workspace_v2", "start", "--name", workspaceName})
+func (ac *AnyscaleCLI) startWorkspace(workspaceID string) error {
+	_, err := ac.runAnyscaleCLI([]string{"workspace_v2", "start", "--id", workspaceID})
 	if err != nil {
 		return fmt.Errorf("start workspace failed: %w", err)
 	}
 	return nil
 }
 
-func (ac *AnyscaleCLI) getWorkspaceStatus(workspaceName string) (string, error) {
-	output, err := ac.runAnyscaleCLI([]string{"workspace_v2", "status", "--name", workspaceName})
+func (ac *AnyscaleCLI) getWorkspaceStatus(workspaceID string) (string, error) {
+	output, err := ac.runAnyscaleCLI([]string{"workspace_v2", "status", "--id", workspaceID})
 	if err != nil {
 		return "", fmt.Errorf("get workspace state failed: %w", err)
 	}
@@ -145,11 +151,11 @@ func (ac *AnyscaleCLI) getWorkspaceStatus(workspaceName string) (string, error) 
 }
 
 func (ac *AnyscaleCLI) waitForWorkspaceState(
-	workspaceName string,
+	workspaceID string,
 	state WorkspaceState,
 ) (string, error) {
 	output, err := ac.runAnyscaleCLI(
-		[]string{"workspace_v2", "wait", "--name", workspaceName, "--state", state.String()},
+		[]string{"workspace_v2", "wait", "--id", workspaceID, "--state", state.String()},
 	)
 	if err != nil {
 		return "", fmt.Errorf("wait for workspace state failed: %w", err)

--- a/rayapp/anyscale_cli_workspace_v2_test.go
+++ b/rayapp/anyscale_cli_workspace_v2_test.go
@@ -47,12 +47,12 @@ func TestGetWorkspaceDescription(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "get"},
 				[]string{"--json"},
-				[][2]string{{"--name", "my-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return fake.run(args)
 		})
 
-		got, err := cli.getWorkspaceDescription("my-workspace")
+		got, err := cli.getWorkspaceDescription("expwrk_abc123")
 		if err != nil {
 			t.Fatalf("getWorkspaceDescription() error = %v", err)
 		}
@@ -73,12 +73,12 @@ func TestGetWorkspaceDescription(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "get"},
 				[]string{"--json"},
-				[][2]string{{"--name", "my-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		_, err := cli.getWorkspaceDescription("my-workspace")
+		_, err := cli.getWorkspaceDescription("expwrk_abc123")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -93,111 +93,17 @@ func TestGetWorkspaceDescription(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "get"},
 				[]string{"--json"},
-				[][2]string{{"--name", "my-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return "not valid json", nil
 		})
 
-		_, err := cli.getWorkspaceDescription("my-workspace")
+		_, err := cli.getWorkspaceDescription("expwrk_abc123")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), "parse workspace get output") {
 			t.Errorf("error %q should contain 'parse workspace get output'", err.Error())
-		}
-	})
-}
-
-func TestGetWorkspaceID(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		fake := &fakeAnyscale{
-			workspaces: []*fakeWorkspace{{
-				ID: "expwrk_xyz789", Name: "test-ws",
-			}},
-		}
-		cli := NewAnyscaleCLI()
-		cli.setRunFunc(func(args []string) (string, error) {
-			checkArgs(t, args,
-				[]string{"workspace_v2", "get"},
-				[]string{"--json"},
-				[][2]string{{"--name", "test-ws"}},
-			)
-			return fake.run(args)
-		})
-
-		got, err := cli.getWorkspaceID("test-ws")
-		if err != nil {
-			t.Fatalf("getWorkspaceID() error = %v", err)
-		}
-		if got != "expwrk_xyz789" {
-			t.Errorf("getWorkspaceID() = %q, want expwrk_xyz789", got)
-		}
-	})
-
-	t.Run("getWorkspaceDescription fails", func(t *testing.T) {
-		fake := &fakeAnyscale{
-			workspaces: []*fakeWorkspace{
-				{
-					ID: "expwrk_xyz789", Name: "my-workspace-2", State: "RUNNING",
-				},
-			},
-		}
-		cli := NewAnyscaleCLI()
-		cli.setRunFunc(func(args []string) (string, error) {
-			checkArgs(t, args,
-				[]string{"workspace_v2", "get"},
-				[]string{"--json"},
-				[][2]string{{"--name", "my-workspace"}},
-			)
-			return fake.run(args)
-		})
-
-		_, err := cli.getWorkspaceID("my-workspace")
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "get workspace description failed") {
-			t.Errorf("error %q should contain 'get workspace description failed'", err.Error())
-		}
-	})
-
-	t.Run("id missing in description", func(t *testing.T) {
-		cli := NewAnyscaleCLI()
-		cli.setRunFunc(func(args []string) (string, error) {
-			checkArgs(t, args,
-				[]string{"workspace_v2", "get"},
-				[]string{"--json"},
-				[][2]string{{"--name", "no-id-workspace"}},
-			)
-			return `{"name": "no-id-workspace"}`, nil
-		})
-
-		_, err := cli.getWorkspaceID("no-id-workspace")
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "workspace ID not found in description") {
-			t.Errorf("error %q should contain 'workspace ID not found in description'", err.Error())
-		}
-	})
-
-	t.Run("id not a string", func(t *testing.T) {
-		cli := NewAnyscaleCLI()
-		cli.setRunFunc(func(args []string) (string, error) {
-			checkArgs(t, args,
-				[]string{"workspace_v2", "get"},
-				[]string{"--json"},
-				[][2]string{{"--name", "bad-id"}},
-			)
-			return `{"id": 12345, "name": "bad-id"}`, nil
-		})
-
-		_, err := cli.getWorkspaceID("bad-id")
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "workspace ID not found in description") {
-			t.Errorf("error %q should contain 'workspace ID not found in description'", err.Error())
 		}
 	})
 }
@@ -210,6 +116,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 		runFunc     func(args []string) (string, error)
 		config      *WorkspaceTestConfig
 		wantPairs   [][2]string
+		wantID      string
 		wantErr     bool
 		errContains string
 	}{
@@ -229,6 +136,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--image-uri", "anyscale/ray:2.44.1-py312-cu128"},
 				{"--ray-version", "2.44.1"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "success with compute config name",
@@ -248,6 +156,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--ray-version", "2.44.1"},
 				{"--compute-config", "basic-single-node-aws"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "success with BYOD containerfile",
@@ -269,6 +178,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--containerfile", filepath.Join("foo", "bar", "Dockerfile")},
 				{"--ray-version", "2.34.0"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "success with BYOD docker image",
@@ -289,6 +199,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--image-uri", "my-custom-image:latest"},
 				{"--ray-version", "2.34.0"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "success with ImageURI",
@@ -304,6 +215,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--image-uri", "anyscale/ray:2.44.1-py312-cu128"},
 				{"--ray-version", "2.44.1"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "success with ImageURI and compute config",
@@ -323,6 +235,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				{"--ray-version", "2.35.0"},
 				{"--compute-config", "basic-single-node-aws"},
 			},
+			wantID: "expwrk_test-workspace",
 		},
 		{
 			name:    "nil template",
@@ -368,6 +281,27 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 			wantErr:     true,
 			errContains: "create empty workspace failed",
 		},
+		{
+			name: "create output missing id",
+			runFunc: func(args []string) (string, error) {
+				return "Workspace created successfully", nil
+			},
+			config: &WorkspaceTestConfig{
+				workspaceName: "test-workspace",
+				template: &Template{
+					ClusterEnv: &ClusterEnv{
+						BuildID: "anyscaleray2441-py312-cu128",
+					},
+				},
+			},
+			wantPairs: [][2]string{
+				{"--name", "test-workspace"},
+				{"--image-uri", "anyscale/ray:2.44.1-py312-cu128"},
+				{"--ray-version", "2.44.1"},
+			},
+			wantErr:     true,
+			errContains: "could not parse workspace id",
+		},
 	}
 
 	for _, tt := range tests {
@@ -378,7 +312,7 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 				return tt.runFunc(args)
 			})
 
-			err := cli.createEmptyWorkspace(tt.config)
+			gotID, err := cli.createEmptyWorkspace(tt.config)
 
 			if tt.wantErr {
 				if err == nil {
@@ -393,6 +327,9 @@ func TestCreateEmptyWorkspace(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			if gotID != tt.wantID {
+				t.Errorf("createEmptyWorkspace() id = %q, want %q", gotID, tt.wantID)
+			}
 		})
 	}
 }
@@ -406,14 +343,14 @@ func TestPushFolderToWorkspace(t *testing.T) {
 				[]string{"workspace_v2", "push"},
 				nil,
 				[][2]string{
-					{"--name", "my-workspace"},
+					{"--id", "expwrk_abc123"},
 					{"--local-dir", "/local/path"},
 				},
 			)
 			return fake.run(args)
 		})
 
-		err := cli.pushFolderToWorkspace("my-workspace", "/local/path")
+		err := cli.pushFolderToWorkspace("expwrk_abc123", "/local/path")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -426,14 +363,14 @@ func TestPushFolderToWorkspace(t *testing.T) {
 				[]string{"workspace_v2", "push"},
 				nil,
 				[][2]string{
-					{"--name", "my-workspace"},
+					{"--id", "expwrk_abc123"},
 					{"--local-dir", "/local/path"},
 				},
 			)
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		err := cli.pushFolderToWorkspace("my-workspace", "/local/path")
+		err := cli.pushFolderToWorkspace("expwrk_abc123", "/local/path")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -451,12 +388,12 @@ func TestTerminateWorkspace(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "terminate"},
 				nil,
-				[][2]string{{"--name", "my-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return fake.run(args)
 		})
 
-		err := cli.terminateWorkspace("my-workspace")
+		err := cli.terminateWorkspace("expwrk_abc123")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -468,12 +405,12 @@ func TestTerminateWorkspace(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "terminate"},
 				nil,
-				[][2]string{{"--name", "my-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		err := cli.terminateWorkspace("my-workspace")
+		err := cli.terminateWorkspace("expwrk_abc123")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -492,7 +429,7 @@ func TestTerminateWorkspace(t *testing.T) {
 func TestRunCmdInWorkspace(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		fake := &fakeAnyscale{}
-		pairs := [][2]string{{"--name", "test-workspace"}}
+		pairs := [][2]string{{"--id", "expwrk_abc123"}}
 		cli := NewAnyscaleCLI()
 		cli.setRunFunc(func(args []string) (string, error) {
 			checkArgs(t, args, []string{"workspace_v2", "run_command"}, nil, pairs)
@@ -504,14 +441,14 @@ func TestRunCmdInWorkspace(t *testing.T) {
 			return fake.run(args)
 		})
 
-		err := cli.runCmdInWorkspace("test-workspace", "echo hello")
+		err := cli.runCmdInWorkspace("expwrk_abc123", "echo hello")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		pairs := [][2]string{{"--name", "test-workspace"}}
+		pairs := [][2]string{{"--id", "expwrk_abc123"}}
 		cli := NewAnyscaleCLI()
 		cli.setRunFunc(func(args []string) (string, error) {
 			checkArgs(t, args, []string{"workspace_v2", "run_command"}, nil, pairs)
@@ -523,7 +460,7 @@ func TestRunCmdInWorkspace(t *testing.T) {
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		err := cli.runCmdInWorkspace("test-workspace", "failing-command")
+		err := cli.runCmdInWorkspace("expwrk_abc123", "failing-command")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -543,12 +480,12 @@ func TestStartWorkspace(t *testing.T) {
 				args,
 				[]string{"workspace_v2", "start"},
 				nil,
-				[][2]string{{"--name", "test-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return fake.run(args)
 		})
 
-		err := cli.startWorkspace("test-workspace")
+		err := cli.startWorkspace("expwrk_abc123")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -560,12 +497,12 @@ func TestStartWorkspace(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "start"},
 				nil,
-				[][2]string{{"--name", "test-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		err := cli.startWorkspace("test-workspace")
+		err := cli.startWorkspace("expwrk_abc123")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -579,7 +516,7 @@ func TestGetWorkspaceStatus(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		fake := &fakeAnyscale{
 			workspaces: []*fakeWorkspace{{
-				Name: "test-workspace", State: "RUNNING",
+				ID: "expwrk_abc123", Name: "test-workspace", State: "RUNNING",
 			}},
 		}
 		cli := NewAnyscaleCLI()
@@ -589,12 +526,12 @@ func TestGetWorkspaceStatus(t *testing.T) {
 				args,
 				[]string{"workspace_v2", "status"},
 				nil,
-				[][2]string{{"--name", "test-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return fake.run(args)
 		})
 
-		output, err := cli.getWorkspaceStatus("test-workspace")
+		output, err := cli.getWorkspaceStatus("expwrk_abc123")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -609,12 +546,12 @@ func TestGetWorkspaceStatus(t *testing.T) {
 			checkArgs(t, args,
 				[]string{"workspace_v2", "status"},
 				nil,
-				[][2]string{{"--name", "test-workspace"}},
+				[][2]string{{"--id", "expwrk_abc123"}},
 			)
 			return "", fmt.Errorf("exit status 1")
 		})
 
-		_, err := cli.getWorkspaceStatus("test-workspace")
+		_, err := cli.getWorkspaceStatus("expwrk_abc123")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -633,7 +570,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 				[]string{"workspace_v2", "wait"},
 				nil,
 				[][2]string{
-					{"--name", "test-workspace"},
+					{"--id", "expwrk_abc123"},
 					{"--state", "RUNNING"},
 				},
 			)
@@ -641,7 +578,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 		})
 
 		output, err := cli.waitForWorkspaceState(
-			"test-workspace", StateRunning,
+			"expwrk_abc123", StateRunning,
 		)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -669,7 +606,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 				[]string{"workspace_v2", "wait"},
 				nil,
 				[][2]string{
-					{"--name", "test-workspace"},
+					{"--id", "expwrk_abc123"},
 					{"--state", "TERMINATED"},
 				},
 			)
@@ -677,7 +614,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 		})
 
 		output, err := cli.waitForWorkspaceState(
-			"test-workspace", StateTerminated,
+			"expwrk_abc123", StateTerminated,
 		)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -704,7 +641,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 				[]string{"workspace_v2", "wait"},
 				nil,
 				[][2]string{
-					{"--name", "test-workspace"},
+					{"--id", "expwrk_abc123"},
 					{"--state", "RUNNING"},
 				},
 			)
@@ -712,7 +649,7 @@ func TestWaitForWorkspaceState(t *testing.T) {
 		})
 
 		_, err := cli.waitForWorkspaceState(
-			"test-workspace", StateRunning,
+			"expwrk_abc123", StateRunning,
 		)
 		if err == nil {
 			t.Fatal("expected error, got nil")

--- a/rayapp/template_test_runner.go
+++ b/rayapp/template_test_runner.go
@@ -241,23 +241,19 @@ func (c *WorkspaceTestConfig) setupEmptyWorkspace() {
 		}
 	}
 
-	if err := c.anyscaleCLI.createEmptyWorkspace(c); err != nil {
-		c.errs = append(c.errs, fmt.Errorf("create empty workspace failed: %w", err))
-		return
-	}
-	workspaceID, err := c.anyscaleCLI.getWorkspaceID(c.workspaceName)
+	workspaceID, err := c.anyscaleCLI.createEmptyWorkspace(c)
 	if err != nil {
-		c.errs = append(c.errs, fmt.Errorf("get workspace ID failed: %w", err))
+		c.errs = append(c.errs, fmt.Errorf("create empty workspace failed: %w", err))
 		return
 	}
 	c.workspaceID = workspaceID
 
-	if err := c.anyscaleCLI.startWorkspace(c.workspaceName); err != nil {
+	if err := c.anyscaleCLI.startWorkspace(c.workspaceID); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("start workspace failed: %w", err))
 		return
 	}
 
-	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceName, StateRunning); err != nil {
+	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceID, StateRunning); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("wait for workspace running state failed: %w", err))
 		return
 	}
@@ -275,13 +271,13 @@ func (c *WorkspaceTestConfig) setupEmptyWorkspace() {
 		return
 	}
 
-	if err := c.anyscaleCLI.pushFolderToWorkspace(c.workspaceName, templateZipDir); err != nil {
+	if err := c.anyscaleCLI.pushFolderToWorkspace(c.workspaceID, templateZipDir); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("push template to workspace failed: %w", err))
 		return
 	}
 
 	unzipCmd := fmt.Sprintf("unzip -o %s.zip", c.tmplName)
-	if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceName, unzipCmd); err != nil {
+	if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceID, unzipCmd); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("unzip template failed: %w", err))
 		return
 	}
@@ -318,7 +314,7 @@ func (c *WorkspaceTestConfig) setupTemplateWorkspace() {
 	}
 	c.workspaceName = workspaceName
 	c.workspaceID = workspaceID
-	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceName, StateRunning); err != nil {
+	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceID, StateRunning); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("wait for workspace running state failed: %w", err))
 		return
 	}
@@ -326,11 +322,15 @@ func (c *WorkspaceTestConfig) setupTemplateWorkspace() {
 
 func (c *WorkspaceTestConfig) cleanup() {
 	log.Println("Cleaning up workspace...")
-	if err := c.anyscaleCLI.terminateWorkspace(c.workspaceName); err != nil {
+	if c.workspaceID == "" {
+		log.Println("Workspace was never created, nothing to clean up.")
+		return
+	}
+	if err := c.anyscaleCLI.terminateWorkspace(c.workspaceID); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("terminate workspace failed: %w", err))
 		return
 	}
-	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceName, StateTerminated); err != nil {
+	if _, err := c.anyscaleCLI.waitForWorkspaceState(c.workspaceID, StateTerminated); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("wait for workspace terminated state failed: %w", err))
 		return
 	}
@@ -387,13 +387,13 @@ func (c *WorkspaceTestConfig) Run() {
 		}
 
 		// Push test zip to workspace
-		if err := c.anyscaleCLI.pushFolderToWorkspace(c.workspaceName, testZipDir); err != nil {
+		if err := c.anyscaleCLI.pushFolderToWorkspace(c.workspaceID, testZipDir); err != nil {
 			c.errs = append(c.errs, fmt.Errorf("push test zip to workspace failed: %w", err))
 			return
 		}
 
 		// Unzip test folder in workspace
-		if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceName, "unzip -o tests.zip"); err != nil {
+		if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceID, "unzip -o tests.zip"); err != nil {
 			c.errs = append(c.errs, fmt.Errorf("unzip tests in workspace failed: %w", err))
 			return
 		}
@@ -403,7 +403,7 @@ func (c *WorkspaceTestConfig) Run() {
 	// Escape single quotes to prevent command injection via bash -c '...'.
 	escapedCmd := strings.ReplaceAll(c.template.Test.Command, "'", "'\\''")
 	testCommand := fmt.Sprintf("timeout %d bash -c '%s'", c.template.Test.TimeoutInSec, escapedCmd)
-	if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceName, testCommand); err != nil {
+	if err := c.anyscaleCLI.runCmdInWorkspace(c.workspaceID, testCommand); err != nil {
 		c.errs = append(c.errs, fmt.Errorf("run test command failed: %w", err))
 		return
 	}

--- a/rayapp/template_test_runner_test.go
+++ b/rayapp/template_test_runner_test.go
@@ -109,13 +109,6 @@ func TestWorkspaceTestConfigRun(t *testing.T) {
 			wantErr: "create empty workspace failed",
 		},
 		{
-			name: "get workspace ID fails",
-			commandErrors: map[string]error{
-				"workspace_v2 get": fmt.Errorf("get failed"),
-			},
-			wantErr: "get workspace ID failed",
-		},
-		{
 			name: "start workspace fails",
 			commandErrors: map[string]error{
 				"workspace_v2 start": fmt.Errorf("start failed"),


### PR DESCRIPTION
## Why

The Anyscale API endpoint backing `anyscale workspace_v2 <op> --name <name>`
(`GET /api/v2/experimental_workspaces/`) was observed returning HTTP 404 on
`console.anyscale-staging.com`. The by-id endpoint
(`GET /api/v2/experimental_workspaces/{workspace_id}`) is unaffected.

Because the CLI swallows the 404 and reports it as
`Workspace with name '<name>' was not found.`, `rayapp test` fails
immediately after creating a workspace — the next step is
`workspace_v2 get --name ...`, which can never succeed even though the
workspace exists. The misleading error was reproduced on anyscale CLI
versions 0.26.87, 0.26.95, 0.26.99, and 0.26.100, confirming the regression
is server-side, not in the CLI.

## What changed

`rayapp` now captures the workspace id from `workspace_v2 create` stdout/stderr
(`Workspace created successfully id: expwrk_...`) and passes `--id <id>` to
every subsequent `workspace_v2` subcommand. The by-name code path is removed.
