### PR TITLE
[DO NOT MERGE] [raycicmd] Add experimental runner queues for gpu, gpu-large, g6-large

### DIFF
--- a/raycicmd/builtin_configs.go
+++ b/raycicmd/builtin_configs.go
@@ -29,6 +29,11 @@ var branchPipelineConfig = &config{
 		"medium-arm64":   "runner_queue_arm64_medium_branch",
 		"release":        "release_queue_small",
 		"release-medium": "release_queue_medium",
+
+		// Experimental queues.
+		"gpu-experimental":       "gpu_experimental_runner_queue_branch",
+		"gpu-large-experimental": "gpu_large_experimental_runner_queue_branch",
+		"g6-large-experimental":  "g6_large_experimental_runner_queue_branch",
 	},
 
 	Env: map[string]string{
@@ -75,6 +80,11 @@ func makePRPipelineConfig(name string) *config {
 			"macos-arm64": "macos-pr-arm64",
 
 			"medium-arm64": "runner_queue_arm64_medium_pr",
+
+			// Experimental queues.
+			"gpu-experimental":       "gpu_experimental_runner_queue_pr",
+			"gpu-large-experimental": "gpu_large_experimental_runner_queue_pr",
+			"g6-large-experimental":  "g6_large_experimental_runner_queue_pr",
 		},
 
 		BuilderPriority: 1,


### PR DESCRIPTION
## What

Adds experimental runner queue mappings to both the PR and branch pipeline configs in `raycicmd/builtin_configs.go` for the `gpu`, `gpu-large`, and `g6-large` instance types.

New queue key names → reef runner queue names:

| Queue key | Branch | PR |
|---|---|---|
| `gpu-experimental` | `gpu_experimental_runner_queue_branch` | `gpu_experimental_runner_queue_pr` |
| `gpu-large-experimental` | `gpu_large_experimental_runner_queue_branch` | `gpu_large_experimental_runner_queue_pr` |
| `g6-large-experimental` | `g6_large_experimental_runner_queue_branch` | `g6_large_experimental_runner_queue_pr` |

These follow the existing naming convention (`<type>-experimental` key → `<type>_experimental_runner_queue_<branch|pr>` value) and are grouped as a separate, commented section at the end of each `RunnerQueues` map.

## Testing

`go build .` and `go test ./raycicmd/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)